### PR TITLE
Track per-segment usage stats

### DIFF
--- a/src/Fugu.Core/Actors/CompactionActor.cs
+++ b/src/Fugu.Core/Actors/CompactionActor.cs
@@ -5,7 +5,7 @@ namespace Fugu.Core.Actors;
 
 public class CompactionActor : Actor
 {
-    private readonly ChannelReader<DummyMessage> _segmentStatsUpdatedChannelReader;
+    private readonly ChannelReader<SegmentStatsUpdatedMessage> _segmentStatsUpdatedChannelReader;
     private readonly ChannelReader<DummyMessage> _segmentEmptiedChannelReader;
     private readonly ChannelReader<DummyMessage> _snapshotsUpdatedChannelReader;
     private readonly ChannelWriter<UpdateIndexMessage> _updateIndexChannelWriter;
@@ -14,7 +14,7 @@ public class CompactionActor : Actor
     private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1);
 
     public CompactionActor(
-        ChannelReader<DummyMessage> segmentStatsUpdatedChannelReader,
+        ChannelReader<SegmentStatsUpdatedMessage> segmentStatsUpdatedChannelReader,
         ChannelReader<DummyMessage> segmentEmptiedChannelReader,
         ChannelReader<DummyMessage> snapshotsUpdatedChannelReader,
         ChannelWriter<UpdateIndexMessage> updateIndexChannelWriter,

--- a/src/Fugu.Core/Actors/IndexActor.cs
+++ b/src/Fugu.Core/Actors/IndexActor.cs
@@ -1,6 +1,5 @@
 ﻿using Fugu.Core.Actors.Messages;
 using Fugu.Core.Common;
-using Fugu.Core.IO;
 using System.Collections.Immutable;
 using System.Threading.Channels;
 
@@ -35,30 +34,55 @@ public class IndexActor : Actor
         {
             if (_updateIndexChannelReader.TryRead(out var message))
             {
+                // We'll use this to track stats changes
+                var statsChanges = new Dictionary<Segment, SegmentStatsChange>();
+
                 var builder = _index.ToBuilder();
 
-                // Update index
+                // Update index: handle writes
                 foreach (var (key, payloadLocator) in message.Payloads)
                 {
                     var indexEntry = new IndexEntry(message.Segment, payloadLocator);
 
                     if (builder.TryGetValue(key, out var previousIndexEntry))
                     {
-                        // TODO: Handle previous value being displaced
+                        // Displacing an existing key in the index
+                        var prevStats = statsChanges.GetValueOrDefault(previousIndexEntry.Segment);
+                        prevStats = prevStats with { BytesDisplaced = prevStats.BytesDisplaced + key.Length + previousIndexEntry.PayloadLocator.Size };
+                        statsChanges[previousIndexEntry.Segment] = prevStats;
                     }
+
+                    var stats = statsChanges.GetValueOrDefault(message.Segment);
+                    stats = stats with { LiveBytesWritten = stats.LiveBytesWritten + key.Length + payloadLocator.Size };
+                    statsChanges[message.Segment] = stats;
 
                     builder[key] = indexEntry;
                 }
 
+                // Update index: handle removals
                 foreach (var key in message.Removals)
                 {
                     if (builder.Remove(key, out var previousIndexEntry))
                     {
-                        // TODO: Handle a value having been removed
+                        // Displacing an existing key in the index
+                        var prevStats = statsChanges.GetValueOrDefault(previousIndexEntry.Segment);
+                        prevStats = prevStats with { BytesDisplaced = prevStats.BytesDisplaced + key.Length + previousIndexEntry.PayloadLocator.Size };
+                        statsChanges[previousIndexEntry.Segment] = prevStats;
+
+                        var stats = statsChanges.GetValueOrDefault(message.Segment);
+                        stats = stats with { LiveBytesWritten = stats.LiveBytesWritten + key.Length };
+                        statsChanges[message.Segment] = stats;
                     }
                     else
                     {
-                        // Removal was a dud
+                        // Removal attempt was a dud, there was nothing in the index
+                        var stats = statsChanges.GetValueOrDefault(message.Segment);
+                        stats = stats with
+                        {
+                            LiveBytesWritten = stats.LiveBytesWritten + key.Length,
+                            BytesDisplaced = stats.BytesDisplaced + key.Length,
+                        };
+                        statsChanges[message.Segment] = stats;
                     }
                 }
 
@@ -76,6 +100,7 @@ public class IndexActor : Actor
                     new UpdateSegmentStatsMessage
                     {
                         Clock = message.Clock,
+                        StatsChanges = statsChanges,
                     });
             }
         }

--- a/src/Fugu.Core/Actors/Messages/SegmentStatsChange.cs
+++ b/src/Fugu.Core/Actors/Messages/SegmentStatsChange.cs
@@ -1,0 +1,5 @@
+﻿namespace Fugu.Core.Actors.Messages;
+
+public readonly record struct SegmentStatsChange(
+    long LiveBytesWritten,
+    long BytesDisplaced);

--- a/src/Fugu.Core/Actors/Messages/SegmentStatsUpdatedMessage.cs
+++ b/src/Fugu.Core/Actors/Messages/SegmentStatsUpdatedMessage.cs
@@ -1,0 +1,7 @@
+﻿using Fugu.Core.Common;
+
+namespace Fugu.Core.Actors.Messages;
+
+public readonly record struct SegmentStatsUpdatedMessage(
+    VectorClock Clock,
+    IReadOnlyDictionary<Segment, SegmentStats> SegmentStats);

--- a/src/Fugu.Core/Actors/Messages/UpdateSegmentStatsMessage.cs
+++ b/src/Fugu.Core/Actors/Messages/UpdateSegmentStatsMessage.cs
@@ -3,4 +3,5 @@
 namespace Fugu.Core.Actors.Messages;
 
 public readonly record struct UpdateSegmentStatsMessage(
-    VectorClock Clock);
+    VectorClock Clock,
+    IReadOnlyDictionary<Segment, SegmentStatsChange> StatsChanges);

--- a/src/Fugu.Core/Actors/SegmentStatsActor.cs
+++ b/src/Fugu.Core/Actors/SegmentStatsActor.cs
@@ -8,7 +8,7 @@ namespace Fugu.Core.Actors;
 public class SegmentStatsActor : Actor
 {
     private readonly ChannelReader<UpdateSegmentStatsMessage> _updateSegmentStatsChannelReader;
-    private readonly ChannelWriter<DummyMessage> _segmentStatsUpdatedChannelWriter;
+    private readonly ChannelWriter<SegmentStatsUpdatedMessage> _segmentStatsUpdatedChannelWriter;
     private readonly ChannelWriter<DummyMessage> _segmentEmptiedChannelWriter;
 
     private ImmutableDictionary<Segment, SegmentStats> _segmentStats =
@@ -16,7 +16,7 @@ public class SegmentStatsActor : Actor
 
     public SegmentStatsActor(
         ChannelReader<UpdateSegmentStatsMessage> updateSegmentStatsChannelReader,
-        ChannelWriter<DummyMessage> segmentStatsUpdatedChannelWriter,
+        ChannelWriter<SegmentStatsUpdatedMessage> segmentStatsUpdatedChannelWriter,
         ChannelWriter<DummyMessage> segmentEmptiedChannelWriter)
     {
         _updateSegmentStatsChannelReader = updateSegmentStatsChannelReader;
@@ -49,6 +49,13 @@ public class SegmentStatsActor : Actor
                 }
 
                 _segmentStats = builder.ToImmutable();
+
+                await _segmentStatsUpdatedChannelWriter.WriteAsync(
+                    new SegmentStatsUpdatedMessage
+                    {
+                        Clock = message.Clock,
+                        SegmentStats = _segmentStats,
+                    });
             }
         }
 

--- a/src/Fugu.Core/Actors/SegmentStatsActor.cs
+++ b/src/Fugu.Core/Actors/SegmentStatsActor.cs
@@ -1,4 +1,6 @@
 ﻿using Fugu.Core.Actors.Messages;
+using Fugu.Core.Common;
+using System.Collections.Immutable;
 using System.Threading.Channels;
 
 namespace Fugu.Core.Actors;
@@ -8,6 +10,9 @@ public class SegmentStatsActor : Actor
     private readonly ChannelReader<UpdateSegmentStatsMessage> _updateSegmentStatsChannelReader;
     private readonly ChannelWriter<DummyMessage> _segmentStatsUpdatedChannelWriter;
     private readonly ChannelWriter<DummyMessage> _segmentEmptiedChannelWriter;
+
+    private ImmutableDictionary<Segment, SegmentStats> _segmentStats =
+        ImmutableDictionary<Segment, SegmentStats>.Empty;
 
     public SegmentStatsActor(
         ChannelReader<UpdateSegmentStatsMessage> updateSegmentStatsChannelReader,
@@ -30,6 +35,20 @@ public class SegmentStatsActor : Actor
         {
             if (_updateSegmentStatsChannelReader.TryRead(out var message))
             {
+                var builder = _segmentStats.ToBuilder();
+
+                foreach (var (segment, change) in message.StatsChanges)
+                {
+                    var stats = builder.GetValueOrDefault(segment);
+
+                    builder[segment] = stats with
+                    {
+                        LiveBytes = stats.LiveBytes + change.LiveBytesWritten - change.BytesDisplaced,
+                        DeadBytes = stats.DeadBytes + change.BytesDisplaced,
+                    };
+                }
+
+                _segmentStats = builder.ToImmutable();
             }
         }
 

--- a/src/Fugu.Core/Common/SegmentStats.cs
+++ b/src/Fugu.Core/Common/SegmentStats.cs
@@ -1,0 +1,8 @@
+﻿namespace Fugu.Core.Common;
+
+public readonly record struct SegmentStats(
+    long LiveBytes,
+    long DeadBytes)
+{
+    public long TotalBytes => LiveBytes + DeadBytes;
+}

--- a/src/Fugu.Core/KeyValueStore.cs
+++ b/src/Fugu.Core/KeyValueStore.cs
@@ -61,6 +61,13 @@ public sealed class KeyValueStore : IAsyncDisposable
             SingleReader = true,
         };
 
+        var dropOldestAsync = new BoundedChannelOptions(capacity: 1)
+        {
+            FullMode = BoundedChannelFullMode.DropOldest,
+            AllowSynchronousContinuations = false,
+            SingleReader = true,
+        };
+
         var allocateWriteBatchChannel = Channel.CreateBounded<AllocateWriteBatchMessage>(defaultBounded);
         var writeWriteBatchChannel = Channel.CreateBounded<WriteWriteBatchMessage>(defaultBounded);
 
@@ -70,14 +77,14 @@ public sealed class KeyValueStore : IAsyncDisposable
         // Consider running two separate channels instead?
         var updateIndexChannel = Channel.CreateBounded<UpdateIndexMessage>(defaultBounded);
         var indexUpdatedChannel = Channel.CreateBounded<IndexUpdatedMessage>(dropOldest);
-        var snapshotsUpdatedChannel = Channel.CreateBounded<DummyMessage>(dropOldest);
+        var snapshotsUpdatedChannel = Channel.CreateBounded<DummyMessage>(dropOldestAsync);
 
         var awaitClockChannel = Channel.CreateBounded<AwaitClockMessage>(defaultBounded);
         var acquireSnapshotChannel = Channel.CreateBounded<AcquireSnapshotMessage>(defaultBounded);
         var releaseSnapshotChannel = Channel.CreateBounded<DummyMessage>(defaultBounded);
 
         var updateSegmentStatsChannel = Channel.CreateBounded<UpdateSegmentStatsMessage>(defaultBounded);
-        var segmentStatsUpdatedChannel = Channel.CreateBounded<DummyMessage>(dropOldest);
+        var segmentStatsUpdatedChannel = Channel.CreateBounded<SegmentStatsUpdatedMessage>(dropOldestAsync);
 
         var segmentEmptiedChannel = Channel.CreateUnbounded<DummyMessage>();
         var segmentEvictedChannel = Channel.CreateUnbounded<DummyMessage>();


### PR DESCRIPTION
When merging individual writes into the primary index, we check if the index already contains an entry for that key to determine if a previous value just got displaced by the new write or delete. We'll then aggregate & transmit these deltas to `SegmentStatsActor`. That actor keeps a ledger of the total number of "live" and "dead" bytes for each known segment.

Going forward, this ledger will be the basis to decide if the store must be compacted, and if yes, which segments should be involved in the compaction to restore invariants.