### PR TITLE
Add component-wise maximum for vector clocks

### DIFF
--- a/src/Fugu.Core/Actors/SnapshotsActor.cs
+++ b/src/Fugu.Core/Actors/SnapshotsActor.cs
@@ -50,6 +50,7 @@ public class SnapshotsActor : Actor
             {
                 if (_indexUpdatedChannelReader.TryRead(out var message))
                 {
+                    _clock = VectorClock.Max(_clock, message.Clock);
                     _index = message.Index;
                 }
             }

--- a/src/Fugu.Core/Common/VectorClock.cs
+++ b/src/Fugu.Core/Common/VectorClock.cs
@@ -13,4 +13,9 @@ public readonly record struct VectorClock(
     {
         return lhs.Write <= rhs.Write && lhs.Compaction <= lhs.Compaction;
     }
+
+    public static VectorClock Max(VectorClock x, VectorClock y)
+    {
+        return new VectorClock(Math.Max(x.Write, y.Write), Math.Max(x.Compaction, y.Compaction));
+    }
 }

--- a/tests/Fugu.Core.Tests/VectorClockTests.cs
+++ b/tests/Fugu.Core.Tests/VectorClockTests.cs
@@ -21,4 +21,16 @@ public class VectorClockTests
 
         Assert.False(lhs >= rhs);
     }
+
+    [Fact]
+    public void Max_ReturnsComponentWiseMaximum()
+    {
+        var x = new VectorClock(1, 4);
+        var y = new VectorClock(2, 3);
+
+        var max = VectorClock.Max(x, y);
+
+        Assert.Equal(2, max.Write);
+        Assert.Equal(4, max.Compaction);
+    }
 }


### PR DESCRIPTION
Adds a `VectorClock.Max` operation that returns the component-wise maximum of its operands. This will be required to reason about partial and total ordering among events such as index updates and compactions.