### PR TITLE
Ensure output table has sufficient capacity

### DIFF
--- a/src/Fugu.Core/Actors/AllocationActor.cs
+++ b/src/Fugu.Core/Actors/AllocationActor.cs
@@ -7,6 +7,9 @@ namespace Fugu.Core.Actors;
 
 public class AllocationActor : Actor
 {
+    // Minimum size of a table, in bytes
+    private const long MinTableSizeBytes = 1024;
+
     private readonly ChannelReader<AllocateWriteBatchMessage> _allocateWriteBatchChannelReader;
     private readonly ChannelReader<DummyMessage> _segmentEvictedChannelReader;
     private readonly ChannelWriter<WriteWriteBatchMessage> _writeWriteBatchChannelWriter;
@@ -15,6 +18,7 @@ public class AllocationActor : Actor
     private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1);
     private VectorClock _clock = new VectorClock();
     private Table? _outputTable = null;
+    private long _remainingCapacity = 0;
 
     public AllocationActor(
         ChannelReader<AllocateWriteBatchMessage> allocateWriteBatchChannelReader,
@@ -51,11 +55,28 @@ public class AllocationActor : Actor
                     _clock = _clock with { Write = _clock.Write + 1 };
                     await message.ReplyChannelWriter.WriteAsync(_clock);
 
+                    // Figure out how much space we'll need to write the current batch, and end the current
+                    // output table if it won't fit
+                    var spaceRequired = Measurements.Measure(message.Batch);
+
+                    if (spaceRequired > _remainingCapacity)
+                    {
+                        _outputTable = null;
+                        _remainingCapacity = 0;
+                    }
+
                     // Make sure there's an output table with sufficient remaining space for this write
                     if (_outputTable is null)
                     {
-                        _outputTable = await _tableSet.CreateTableAsync(1024);
+                        // Size new output table so that it's guaranteed to fit at least
+                        // the incoming write + segment book-keeping, instead of hardcoded size
+                        var capacity = Math.Max(MinTableSizeBytes, Measurements.SegmentOverheadSize + spaceRequired);
+
+                        _outputTable = await _tableSet.CreateTableAsync(capacity);
+                        _remainingCapacity = capacity - Measurements.SegmentOverheadSize;
                     }
+
+                    _remainingCapacity -= spaceRequired;
 
                     await _writeWriteBatchChannelWriter.WriteAsync(
                         new WriteWriteBatchMessage

--- a/src/Fugu.Core/Actors/WriterActor.cs
+++ b/src/Fugu.Core/Actors/WriterActor.cs
@@ -48,10 +48,13 @@ public class WriterActor : Actor
                         _tableWriter!.Write(in segmentTrailer);
                     }
 
-                    // Initialize new output table
+                    // Determine generation of the new output segment
+                    var outputGeneration = _outputSegment?.MaxGeneration + 1 ?? 1;
+
+                    // Initialize new output segment backed by the current output table
                     _outputTable = message.OutputTable;
                     _tableWriter = new TableWriter(_outputTable.BufferWriter);
-                    _outputSegment = new Segment(1, 1, _outputTable);
+                    _outputSegment = new Segment(outputGeneration, outputGeneration, _outputTable);
 
                     // Write segment header
                     var segmentHeader = new SegmentHeader

--- a/src/Fugu.Core/IO/Measurements.cs
+++ b/src/Fugu.Core/IO/Measurements.cs
@@ -1,0 +1,20 @@
+﻿using Fugu.Core.IO.Format;
+using System.Runtime.CompilerServices;
+
+namespace Fugu.Core.IO;
+
+public static class Measurements
+{
+    // Number of bytes that will be used in each segment for metadata and integrity
+    public static readonly int SegmentOverheadSize =
+        Unsafe.SizeOf<SegmentHeader>() + Unsafe.SizeOf<SegmentTrailer>();
+
+    // Determines the total number of bytes that a given WriteBatch will occupy when written to the backing table set
+    public static long Measure(WriteBatch batch)
+    {
+        long size = Unsafe.SizeOf<CommitHeader>() + Unsafe.SizeOf<CommitTrailer>();
+        size += batch.PendingPuts.Sum((kvp) => (long)(Unsafe.SizeOf<CommitKeyValue>() + kvp.Key.Length + kvp.Value.Length));
+        size += batch.PendingRemovals.Sum(key => (long)key.Length);
+        return size;
+    }
+}


### PR DESCRIPTION
This PR adds a helper class to measure the space requirement for writing out a given `WriteBatch` instance. Based on that information, `AllocationActor` tracks how much space is still left in the current output table, and will roll over to a new output table if the incoming batch wouldn't fit.