### PR TITLE
Surface async I/O in Table API

### DIFF
--- a/examples/BasicDemo/Program.cs
+++ b/examples/BasicDemo/Program.cs
@@ -29,7 +29,13 @@ await using (var store = await KeyValueStore.CreateAsync(tableSet))
     // Read results back
     {
         using var snapshot = await store.GetSnapshotAsync();
-        var buffer = new byte[100];
-        await snapshot.ReadAsync(buffer, Encoding.UTF8.GetBytes("foo"));
+
+        var foo = Encoding.UTF8.GetBytes("foo");
+
+        if (snapshot.TryGetLength(foo, out var length))
+        {
+            var buffer = new byte[length];
+            await snapshot.ReadAsync(foo, buffer);
+        }
     }
 }

--- a/examples/BasicDemo/Program.cs
+++ b/examples/BasicDemo/Program.cs
@@ -29,7 +29,7 @@ await using (var store = await KeyValueStore.CreateAsync(tableSet))
     // Read results back
     {
         using var snapshot = await store.GetSnapshotAsync();
-        var hello = Encoding.UTF8.GetString(
-            snapshot[Encoding.UTF8.GetBytes("foo")]);
+        var buffer = new byte[100];
+        await snapshot.ReadAsync(buffer, Encoding.UTF8.GetBytes("foo"));
     }
 }

--- a/src/Fugu.Core/Actors/AllocationActor.cs
+++ b/src/Fugu.Core/Actors/AllocationActor.cs
@@ -17,7 +17,7 @@ public class AllocationActor : Actor
 
     private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1);
     private VectorClock _clock = new VectorClock();
-    private Table? _outputTable = null;
+    private WritableTable? _outputTable = null;
     private long _remainingCapacity = 0;
 
     public AllocationActor(

--- a/src/Fugu.Core/Actors/Messages/WriteWriteBatchMessage.cs
+++ b/src/Fugu.Core/Actors/Messages/WriteWriteBatchMessage.cs
@@ -6,4 +6,4 @@ namespace Fugu.Core.Actors.Messages;
 public readonly record struct WriteWriteBatchMessage(
     WriteBatch Batch,
     VectorClock Clock,
-    Table OutputTable);
+    WritableTable OutputTable);

--- a/src/Fugu.Core/Actors/WriterActor.cs
+++ b/src/Fugu.Core/Actors/WriterActor.cs
@@ -2,7 +2,6 @@
 using Fugu.Core.Common;
 using Fugu.Core.IO;
 using Fugu.Core.IO.Format;
-using System.IO.Pipelines;
 using System.Threading.Channels;
 
 namespace Fugu.Core.Actors;
@@ -13,7 +12,6 @@ public class WriterActor : Actor
     private readonly ChannelWriter<UpdateIndexMessage> _updateIndexChannelWriter;
 
     private WritableTable? _outputTable;
-    private PipeWriter? _outputPipeWriter;
     private TableWriter? _tableWriter;
     private Segment? _outputSegment;
 
@@ -55,8 +53,7 @@ public class WriterActor : Actor
 
                     // Initialize new output segment backed by the current output table
                     _outputTable = message.OutputTable;
-                    _outputPipeWriter = PipeWriter.Create(_outputTable.OutputStream, new StreamPipeWriterOptions(leaveOpen: true));
-                    _tableWriter = new TableWriter(_outputPipeWriter);
+                    _tableWriter = new TableWriter(_outputTable.Writer);
 
                     _outputSegment = new Segment(outputGeneration, outputGeneration, _outputTable);
 
@@ -133,7 +130,7 @@ public class WriterActor : Actor
                 _tableWriter.Write(in commitTrailer);
 
                 // Flush commit
-                var flushResult = await _outputPipeWriter!.FlushAsync();
+                var flushResult = await _outputTable.Writer.FlushAsync();
 
                 // Tell index actor about this write
                 await _updateIndexChannelWriter.WriteAsync(

--- a/src/Fugu.Core/Actors/WriterActor.cs
+++ b/src/Fugu.Core/Actors/WriterActor.cs
@@ -2,6 +2,7 @@
 using Fugu.Core.Common;
 using Fugu.Core.IO;
 using Fugu.Core.IO.Format;
+using System.IO.Pipelines;
 using System.Threading.Channels;
 
 namespace Fugu.Core.Actors;
@@ -11,7 +12,8 @@ public class WriterActor : Actor
     private readonly ChannelReader<WriteWriteBatchMessage> _writeWriteBatchChannelReader;
     private readonly ChannelWriter<UpdateIndexMessage> _updateIndexChannelWriter;
 
-    private Table? _outputTable;
+    private WritableTable? _outputTable;
+    private PipeWriter? _outputPipeWriter;
     private TableWriter? _tableWriter;
     private Segment? _outputSegment;
 
@@ -53,7 +55,9 @@ public class WriterActor : Actor
 
                     // Initialize new output segment backed by the current output table
                     _outputTable = message.OutputTable;
-                    _tableWriter = new TableWriter(_outputTable.BufferWriter);
+                    _outputPipeWriter = PipeWriter.Create(_outputTable.OutputStream, new StreamPipeWriterOptions(leaveOpen: true));
+                    _tableWriter = new TableWriter(_outputPipeWriter);
+
                     _outputSegment = new Segment(outputGeneration, outputGeneration, _outputTable);
 
                     // Write segment header
@@ -127,6 +131,9 @@ public class WriterActor : Actor
                 };
 
                 _tableWriter.Write(in commitTrailer);
+
+                // Flush commit
+                var flushResult = await _outputPipeWriter!.FlushAsync();
 
                 // Tell index actor about this write
                 await _updateIndexChannelWriter.WriteAsync(

--- a/src/Fugu.Core/Common/Segment.cs
+++ b/src/Fugu.Core/Common/Segment.cs
@@ -4,7 +4,7 @@ namespace Fugu.Core.Common;
 
 public class Segment
 {
-    public Segment(long minGeneration, long maxGeneration, ReadOnlyTable table)
+    public Segment(long minGeneration, long maxGeneration, Table table)
     {
         MinGeneration = minGeneration;
         MaxGeneration = maxGeneration;
@@ -13,5 +13,5 @@ public class Segment
 
     public long MinGeneration { get; }
     public long MaxGeneration { get; }
-    public ReadOnlyTable Table { get; }
+    public Table Table { get; }
 }

--- a/src/Fugu.Core/Fugu.Core.csproj
+++ b/src/Fugu.Core/Fugu.Core.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.IO.Pipelines" Version="7.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/Fugu.Core/IO/InMemoryTable.cs
+++ b/src/Fugu.Core/IO/InMemoryTable.cs
@@ -1,15 +1,19 @@
-﻿namespace Fugu.Core.IO;
+﻿using System.IO.Pipelines;
+
+namespace Fugu.Core.IO;
 
 public class InMemoryTable : WritableTable
 {
     private readonly MemoryStream _stream;
+    private readonly PipeWriter _writer;
 
     public InMemoryTable(int capacity)
     {
         _stream = new MemoryStream(capacity);
+        _writer = PipeWriter.Create(_stream);
     }
 
-    public override Stream OutputStream => _stream;
+    public override PipeWriter Writer => _writer;
 
     public override ValueTask ReadAsync(Memory<byte> buffer, long offset)
     {

--- a/src/Fugu.Core/IO/InMemoryTable.cs
+++ b/src/Fugu.Core/IO/InMemoryTable.cs
@@ -1,20 +1,20 @@
-﻿using System.Buffers;
+﻿namespace Fugu.Core.IO;
 
-namespace Fugu.Core.IO;
-
-public class InMemoryTable : Table
+public class InMemoryTable : WritableTable
 {
-    private readonly ArrayBufferWriter<byte> _arrayBufferWriter;
+    private readonly MemoryStream _stream;
 
     public InMemoryTable(int capacity)
     {
-        _arrayBufferWriter = new ArrayBufferWriter<byte>(capacity);
+        _stream = new MemoryStream(capacity);
     }
 
-    public override ReadOnlySpan<byte> GetSpan(long start, int length)
+    public override Stream OutputStream => _stream;
+
+    public override ValueTask ReadAsync(Memory<byte> buffer, long offset)
     {
-        return _arrayBufferWriter.WrittenSpan.Slice((int)start, length);
+        var contents = _stream.ToArray();
+        contents.AsMemory((int)offset, buffer.Length).CopyTo(buffer);
+        return ValueTask.CompletedTask;
     }
-
-    public override IBufferWriter<byte> BufferWriter => _arrayBufferWriter;
 }

--- a/src/Fugu.Core/IO/ReadOnlyTable.cs
+++ b/src/Fugu.Core/IO/ReadOnlyTable.cs
@@ -1,8 +1,0 @@
-﻿using System.Buffers;
-
-namespace Fugu.Core.IO;
-
-public abstract class ReadOnlyTable
-{
-    public abstract ReadOnlySpan<byte> GetSpan(long start, int length);
-}

--- a/src/Fugu.Core/IO/Table.cs
+++ b/src/Fugu.Core/IO/Table.cs
@@ -2,7 +2,7 @@
 
 namespace Fugu.Core.IO;
 
-public abstract class Table : ReadOnlyTable
+public abstract class Table
 {
-    public abstract IBufferWriter<byte> BufferWriter { get; }
+    public abstract ValueTask ReadAsync(Memory<byte> buffer, long offset);
 }

--- a/src/Fugu.Core/IO/TableReader.cs
+++ b/src/Fugu.Core/IO/TableReader.cs
@@ -14,21 +14,21 @@ public class TableReader
 
     public long Position { get; private set; } = 0;
 
-    public ref readonly T Read<T>() where T : struct
-    {
-        var size = Unsafe.SizeOf<T>();
-        var span = _table.GetSpan(Position, size);
-        ref readonly var value = ref MemoryMarshal.AsRef<T>(span);
+    //public ref readonly T Read<T>() where T : struct
+    //{
+    //    var size = Unsafe.SizeOf<T>();
+    //    var span = _table.GetSpan(Position, size);
+    //    ref readonly var value = ref MemoryMarshal.AsRef<T>(span);
 
-        Position += size;
-        return ref value;
-    }
+    //    Position += size;
+    //    return ref value;
+    //}
 
-    public ReadOnlySpan<byte> ReadBytes(int length)
-    {
-        var value = _table.GetSpan(Position, length);
+    //public ReadOnlySpan<byte> ReadBytes(int length)
+    //{
+    //    var value = _table.GetSpan(Position, length);
 
-        Position += length;
-        return value;
-    }
+    //    Position += length;
+    //    return value;
+    //}
 }

--- a/src/Fugu.Core/IO/WritableTable.cs
+++ b/src/Fugu.Core/IO/WritableTable.cs
@@ -1,6 +1,8 @@
-﻿namespace Fugu.Core.IO;
+﻿using System.IO.Pipelines;
+
+namespace Fugu.Core.IO;
 
 public abstract class WritableTable : Table
 {
-    public abstract Stream OutputStream { get; }
+    public abstract PipeWriter Writer { get; }
 }

--- a/src/Fugu.Core/IO/WritableTable.cs
+++ b/src/Fugu.Core/IO/WritableTable.cs
@@ -1,0 +1,6 @@
+﻿namespace Fugu.Core.IO;
+
+public abstract class WritableTable : Table
+{
+    public abstract Stream OutputStream { get; }
+}

--- a/src/Fugu.Core/InMemoryTableSet.cs
+++ b/src/Fugu.Core/InMemoryTableSet.cs
@@ -4,9 +4,9 @@ namespace Fugu.Core;
 
 public class InMemoryTableSet : TableSet
 {
-    public override ValueTask<Table> CreateTableAsync(long capacity)
+    public override ValueTask<WritableTable> CreateTableAsync(long capacity)
     {
         var table = new InMemoryTable((int)capacity);
-        return ValueTask.FromResult<Table>(table);
+        return ValueTask.FromResult<WritableTable>(table);
     }
 }

--- a/src/Fugu.Core/Snapshot.cs
+++ b/src/Fugu.Core/Snapshot.cs
@@ -11,11 +11,23 @@ public sealed class Snapshot : IDisposable
         _onDispose = onDispose;
     }
 
-    public ValueTask ReadAsync(Memory<byte> buffer, Key key)
+    public bool TryGetLength(Key key, out int length)
+    {
+        if (!_index.TryGetValue(key, out var indexEntry))
+        {
+            length = 0;
+            return false;
+        }
+
+        length = indexEntry.PayloadLocator.Size;
+        return true;
+    }
+
+    public ValueTask ReadAsync(Key key, Memory<byte> buffer)
     {
         var indexEntry = _index[key];
         var payloadLocator = indexEntry.PayloadLocator;
-        return indexEntry.Segment.Table.ReadAsync(buffer.Slice(0, payloadLocator.Size), payloadLocator.Start);
+        return indexEntry.Segment.Table.ReadAsync(buffer[..payloadLocator.Size], payloadLocator.Start);
     }
 
     public void Dispose()

--- a/src/Fugu.Core/Snapshot.cs
+++ b/src/Fugu.Core/Snapshot.cs
@@ -11,15 +11,11 @@ public sealed class Snapshot : IDisposable
         _onDispose = onDispose;
     }
 
-    public ReadOnlySpan<byte> this[Key key]
+    public ValueTask ReadAsync(Memory<byte> buffer, Key key)
     {
-        get
-        {
-            var indexEntry = _index[key];
-            var payloadLocator = indexEntry.PayloadLocator;
-            var span = indexEntry.Segment.Table.GetSpan(payloadLocator.Start, payloadLocator.Size);
-            return span;
-        }
+        var indexEntry = _index[key];
+        var payloadLocator = indexEntry.PayloadLocator;
+        return indexEntry.Segment.Table.ReadAsync(buffer.Slice(0, payloadLocator.Size), payloadLocator.Start);
     }
 
     public void Dispose()

--- a/src/Fugu.Core/TableSet.cs
+++ b/src/Fugu.Core/TableSet.cs
@@ -4,5 +4,5 @@ namespace Fugu.Core;
 
 public abstract class TableSet
 {
-    public abstract ValueTask<Table> CreateTableAsync(long capacity);
+    public abstract ValueTask<WritableTable> CreateTableAsync(long capacity);
 }


### PR DESCRIPTION
The initial concept for Fugu assumed a synchronous-access memory model based on memory-mapped files (MMF). Under this model, accesses to data not yet loaded from disk would trigger a page fault to transparently load the data from disk, stalling the calling thread in the meantime.

After review of [recent literature on the topic](https://db.cs.cmu.edu/mmap-cidr2022/), we decide to use explicit asynchronous file I/O instead. This requires a change in several internal and externally-visible APIs, which this PR implements.