### PR TITLE
Don't report stats for active output segment

### DIFF
--- a/src/Fugu.Core/Actors/IndexActor.cs
+++ b/src/Fugu.Core/Actors/IndexActor.cs
@@ -49,10 +49,10 @@ public sealed partial class IndexActor
             {
                 if (indexBuilder.TryGetValue(tombstone, out var previousIndexEntry))
                 {
-                    indexBuilder.Remove(tombstone);
                     _statsTracker.OnIndexEntryDisplaced(tombstone, previousIndexEntry);
                 }
 
+                indexBuilder.Remove(tombstone);
                 _statsTracker.OnTombstoneAdded(message.OutputSegment, tombstone);
             }
 

--- a/tests/Fugu.Core.Tests/SegmentStatsTrackerTests.cs
+++ b/tests/Fugu.Core.Tests/SegmentStatsTrackerTests.cs
@@ -6,7 +6,7 @@ namespace Fugu.Core.Tests;
 public class SegmentStatsTrackerTests
 {
     [Fact]
-    public async Task OnPayloadAdded_PayloadInUntrackedSegment_TrackedAsLiveBytes()
+    public async Task OnPayloadAdded_DoesNotImmediatelyReflectInStats()
     {
         var tracker = new SegmentStatsTracker();
 
@@ -19,12 +19,33 @@ public class SegmentStatsTrackerTests
 
         var statsBySegment = tracker.ToImmutable();
 
-        // There should now be a single entry in the tracker
-        var singleSegmentStats = Assert.Single(statsBySegment).Value;
-        
+        Assert.Empty(statsBySegment);
+    }
+
+    [Fact]
+    public async Task OnPayloadAdded_SwitchingToNewOutputSegment_PreviousOutputSegmentReflectsInStats()
+    {
+        var tracker = new SegmentStatsTracker();
+
+        var storage = new InMemoryStorage();
+        var slab = await storage.CreateSlabAsync();
+        var segment1 = new Segment(1, 1, slab);
+        var payload1 = new KeyValuePair<byte[], SlabSubrange>("foo"u8.ToArray(), new SlabSubrange(10, 23));
+        var segment2 = new Segment(2, 2, slab);
+        var payload2 = new KeyValuePair<byte[], SlabSubrange>("bar"u8.ToArray(), new SlabSubrange(10, 42));
+
+        tracker.OnPayloadAdded(segment1, payload1);
+        tracker.OnPayloadAdded(segment2, payload2);
+
+        var statsBySegment = tracker.ToImmutable();
+
+        // There should now be a single entry in the tracker for the previous output segment
+        var singleSegmentStats = Assert.Single(statsBySegment);
+        Assert.Equal(segment1, singleSegmentStats.Key);
+
         // The entire combined size of key + value for the payload should count against live bytes
-        Assert.Equal(0, singleSegmentStats.StaleBytes);
-        Assert.Equal(3 + 23, singleSegmentStats.LiveBytes);
-        Assert.Equal(3 + 23, singleSegmentStats.TotalBytes);
+        Assert.Equal(0, singleSegmentStats.Value.StaleBytes);
+        Assert.Equal(3 + 23, singleSegmentStats.Value.LiveBytes);
+        Assert.Equal(3 + 23, singleSegmentStats.Value.TotalBytes);
     }
 }


### PR DESCRIPTION
Up until now, `SegmentStatsTracker` reports stats for all segments represented in the index, including the current output segment. This is problematic for balancing because it might trigger a compaction due to a small volume of data in that segment; worse, including it as a source segment for compaction would conflict with concurrent writes to the segment.

Therefore, this PR proposes to amend `SegmentStatsTracker` such that the current output segment receives special treatment and will not be reported from `ToImmutable()`, hence will not be passed to `CompactionActor` when determining whether the store needs to be rebalanced.