### PR TITLE
Measure storage utilization as a future trigger for compactions

### DIFF
--- a/src/Fugu.Core/Actors/CompactionActor.cs
+++ b/src/Fugu.Core/Actors/CompactionActor.cs
@@ -18,6 +18,31 @@ public sealed class CompactionActor
         {
             var message = await _segmentStatsUpdatedChannel.Reader.ReadAsync();
 
+            // Geometric series characterized by two parameters a and r:
+            const double a = 100;       // Coefficient, also the size of slab #0
+            const double r = 1.5;       // Common ratio, indicates by how much each added slab should be bigger than the last
+
+            // Given the current number n of non-output segments in the store, calculate idealized capacity of the store as the
+            // cumulative sum of an n-element (a, r) geometric series:
+            var n = message.Stats.Count;
+            var capacity = a * (1 - Math.Pow(r, n)) / (1 - r);
+
+            // Calculate actual sum of "live" bytes:
+            var totalLiveBytes = message.Stats.Sum(s => s.Value.LiveBytes);
+
+            // We define utilization as the ratio of "live" bytes to idealized capacity given the current number of non-output
+            // segments. If utilization drops too far below 1.0, this indicates that the store is using too many segments for
+            // the amount of payload data it holds, and should be compacted to flush out stale data.
+            var utilization = totalLiveBytes / capacity;
+
+            // Setting the utilization threshold at 0.5 means that up to 50% of usable space within segments can be taken up
+            // by stale data before a compaction is triggered. Choosing a higher threshold will allow less wasted space, at the
+            // cost of higher write amplification. Choosing a lower threshold will reduce the frequency of compactions, but could
+            // result in more space being wasted by stale data.
+            if (utilization < 0.5)
+            {
+                // TODO: identify a suitable range of segments for compaction
+            }
         }
     }
 }

--- a/src/Fugu.Core/Actors/IndexActor.cs
+++ b/src/Fugu.Core/Actors/IndexActor.cs
@@ -65,10 +65,13 @@ public sealed partial class IndexActor
 
             var stats = _statsTracker.ToImmutable();
 
-            await _segmentStatsUpdatedChannel.Writer.WriteAsync(
-                new SegmentStatsUpdated(
-                    Clock: message.Clock,
-                    Stats: stats));
+            if (!stats.IsEmpty)
+            {
+                await _segmentStatsUpdatedChannel.Writer.WriteAsync(
+                    new SegmentStatsUpdated(
+                        Clock: message.Clock,
+                        Stats: stats));
+            }
         }
 
         // Propagate completion


### PR DESCRIPTION
Currently, `AllocationActor` tracks the amount of space used in each segment to decide when to switch to new output segments with increasingly higher capacity.

This PR extends `CompactionActor` to measure utilization of that capacity by "live" (vs. "stale") data. When the ratio of "live" data vs. total capacity drops below a certain threshold, the store can then identify suitable segments for compaction and copy their "live" contents to a merged segment (compaction itself to be implemented in a future PR).