### PR TITLE
Implement compaction to free up unused space in segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ graph TD;
 
     Index -- SegmentStatsUpdated --> Compaction;
     Snapshots -- OldestObservableSnapshotChanged --> Compaction;
-    Compaction -- ChangesWritten --> Index;
+    Compaction -- CompactionWritten --> Index;
     Compaction -- SegmentsCompacted --> Allocation;
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ graph TD;
     Index -- IndexUpdated --> Snapshots;
 
     Index -- SegmentStatsUpdated --> Compaction;
-    Snapshots -- TBD --> Compaction;
-    Compaction -- TBD --> Index;
-    Compaction -- TBD --> Allocation;
+    Snapshots -- OldestObservableSnapshotChanged --> Compaction;
+    Compaction -- ChangesWritten --> Index;
+    Compaction -- SegmentsCompacted --> Allocation;
 ```
 
 ## Compaction strategy

--- a/samples/BasicDemo/Program.cs
+++ b/samples/BasicDemo/Program.cs
@@ -2,7 +2,7 @@
 using Fugu.IO;
 using System.Text;
 
-const int Iterations = 100;
+const int Iterations = 1000;
 var storage = new InMemoryStorage();
 
 await using (var store = await KeyValueStore.CreateAsync(storage))
@@ -19,7 +19,10 @@ await using (var store = await KeyValueStore.CreateAsync(storage))
         };
 
         await store.SaveAsync(changeSet);
+        await Task.Delay(TimeSpan.FromMilliseconds(10));
     }
+
+    await Task.Delay(TimeSpan.FromSeconds(5));
 
     using (var snapshot = await store.GetSnapshotAsync())
     {

--- a/samples/BasicDemo/Program.cs
+++ b/samples/BasicDemo/Program.cs
@@ -3,6 +3,8 @@ using Fugu.IO;
 using System.Text;
 
 const int Iterations = 10000;
+const int KeyspaceSize = 200;
+
 var storage = new InMemoryStorage();
 
 await using (var store = await KeyValueStore.CreateAsync(storage))
@@ -11,8 +13,8 @@ await using (var store = await KeyValueStore.CreateAsync(storage))
 
     for (var i = 0; i < Iterations; i++)
     {
-        var payloadNo = random.Next(50);
-        var tombstoneNo = random.Next(50);
+        var payloadNo = random.Next(KeyspaceSize);
+        var tombstoneNo = random.Next(KeyspaceSize);
 
         var key = Encoding.UTF8.GetBytes($"key:{payloadNo}");
         var changeSet = new ChangeSet
@@ -30,14 +32,15 @@ await using (var store = await KeyValueStore.CreateAsync(storage))
         //await Task.Delay(TimeSpan.FromMilliseconds(1));
     }
 
-    Console.WriteLine("Writing completed");
-    await Task.Delay(TimeSpan.FromSeconds(5));
+    Console.WriteLine("Writing completed, pausing for 1 second");
+    await Task.Delay(TimeSpan.FromSeconds(1));
 
     using (var snapshot = await store.GetSnapshotAsync())
     {
         foreach (var key in snapshot.Keys)
         {
-            Console.WriteLine($"Key: {Encoding.UTF8.GetString(key.ToArray())}");
+            var value = await snapshot.ReadAsync(key.ToArray());
+            Console.WriteLine($"Key: {Encoding.UTF8.GetString(key.ToArray())} - {Encoding.UTF8.GetString(value.Span)}");
         }
     }
 }

--- a/src/Fugu.Core/Actors/CompactionActor.cs
+++ b/src/Fugu.Core/Actors/CompactionActor.cs
@@ -5,43 +5,96 @@ namespace Fugu.Actors;
 
 public sealed class CompactionActor
 {
+    private readonly SemaphoreSlim _semaphore = new(1);
     private readonly Channel<SegmentStatsUpdated> _segmentStatsUpdatedChannel;
+    private readonly Channel<OldestObservableSnapshotChanged> _oldestObservableSnapshotChangedChannel;
+    private readonly Channel<ChangesWritten> _changesWrittenChannel;
+    private readonly Channel<SegmentsCompacted> _segmentsCompactedChannel;
 
-    public CompactionActor(Channel<SegmentStatsUpdated> segmentStatsUpdatedChannel)
+    public CompactionActor(
+        Channel<SegmentStatsUpdated> segmentStatsUpdatedChannel,
+        Channel<OldestObservableSnapshotChanged> oldestObservableSnapshotChangedChannel,
+        Channel<ChangesWritten> changesWrittenChannel,
+        Channel<SegmentsCompacted> segmentsCompactedChannel)
     {
         _segmentStatsUpdatedChannel = segmentStatsUpdatedChannel;
+        _oldestObservableSnapshotChangedChannel = oldestObservableSnapshotChangedChannel;
+        _changesWrittenChannel = changesWrittenChannel;
+        _segmentsCompactedChannel = segmentsCompactedChannel;
     }
 
     public async Task RunAsync()
     {
+        await Task.WhenAll(
+            ProcessSegmentStatsUpdatedMessagesAsync(),
+            ProcessOldestObservableSnapshotChangedMessagesAsync());
+
+        _segmentsCompactedChannel.Writer.Complete();
+    }
+
+    private async Task ProcessSegmentStatsUpdatedMessagesAsync()
+    {
         while (await _segmentStatsUpdatedChannel.Reader.WaitToReadAsync())
         {
             var message = await _segmentStatsUpdatedChannel.Reader.ReadAsync();
+            await _semaphore.WaitAsync();
 
-            // Geometric series characterized by two parameters a and r:
-            const double a = 100;       // Coefficient, also the size of slab #0
-            const double r = 1.5;       // Common ratio, indicates by how much each added slab should be bigger than the last
-
-            // Given the current number n of non-output segments in the store, calculate idealized capacity of the store as the
-            // cumulative sum of an n-element (a, r) geometric series:
-            var n = message.Stats.Count;
-            var capacity = a * (1 - Math.Pow(r, n)) / (1 - r);
-
-            // Calculate actual sum of "live" bytes:
-            var totalLiveBytes = message.Stats.Sum(s => s.Value.LiveBytes);
-
-            // We define utilization as the ratio of "live" bytes to idealized capacity given the current number of non-output
-            // segments. If utilization drops too far below 1.0, this indicates that the store is using too many segments for
-            // the amount of payload data it holds, and should be compacted to flush out stale data.
-            var utilization = totalLiveBytes / capacity;
-
-            // Setting the utilization threshold at 0.5 means that up to 50% of usable space within segments can be taken up
-            // by stale data before a compaction is triggered. Choosing a higher threshold will allow less wasted space, at the
-            // cost of higher write amplification. Choosing a lower threshold will reduce the frequency of compactions, but could
-            // result in more space being wasted by stale data.
-            if (utilization < 0.5)
+            try
             {
-                // TODO: identify a suitable range of segments for compaction
+                // Geometric series characterized by two parameters a and r:
+                const double a = 100;       // Coefficient, also the size of slab #0
+                const double r = 1.5;       // Common ratio, indicates by how much each added slab should be bigger than the last
+
+                // Given the current number n of non-output segments in the store, calculate idealized capacity of the store as the
+                // cumulative sum of an n-element (a, r) geometric series:
+                var n = message.Stats.Count;
+                var capacity = a * (1 - Math.Pow(r, n)) / (1 - r);
+
+                // Calculate actual sum of "live" bytes:
+                var totalLiveBytes = message.Stats.Sum(s => s.Value.LiveBytes);
+
+                // We define utilization as the ratio of "live" bytes to idealized capacity given the current number of non-output
+                // segments. If utilization drops too far below 1.0, this indicates that the store is using too many segments for
+                // the amount of payload data it holds, and should be compacted to flush out stale data.
+                var utilization = totalLiveBytes / capacity;
+
+                // Setting the utilization threshold at 0.5 means that up to 50% of usable space within segments can be taken up
+                // by stale data before a compaction is triggered. Choosing a higher threshold will allow less wasted space, at the
+                // cost of higher write amplification. Choosing a lower threshold will reduce the frequency of compactions, but could
+                // result in more space being wasted by stale data.
+                if (utilization < 0.5)
+                {
+                    // We need to compact. Identify a suitable range of source segments.
+                    // For each candidate range of segments, we are interested in two numbers:
+                    // - By how much compacting these segments will reduce the idealized capacity; this is dependent only on n.
+                    // - How much data we will likely need to copy during the compaction. Live bytes in source segments for sure;
+                    //   potentially some "stale" bytes as well if they represent tombstones for values that may still exist in
+                    //   previous segments.
+                    // The ratio of both numbers yields the "efficiency" of compacting a specific candidate range, i.e., by how much
+                    // each copied byte will be able to improve the utilization figure.
+                }
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
+        }
+    }
+
+    private async Task ProcessOldestObservableSnapshotChangedMessagesAsync()
+    {
+        while (await _oldestObservableSnapshotChangedChannel.Reader.WaitToReadAsync())
+        {
+            var message = await _oldestObservableSnapshotChangedChannel.Reader.ReadAsync();
+            await _semaphore.WaitAsync();
+
+            try
+            {
+
+            }
+            finally
+            {
+                _semaphore.Release();
             }
         }
     }

--- a/src/Fugu.Core/Actors/CompactionActor.cs
+++ b/src/Fugu.Core/Actors/CompactionActor.cs
@@ -1,4 +1,6 @@
 ﻿using Fugu.Channels;
+using Fugu.IO;
+using Fugu.Utils;
 using System.Threading.Channels;
 
 namespace Fugu.Actors;
@@ -6,17 +8,32 @@ namespace Fugu.Actors;
 public sealed class CompactionActor
 {
     private readonly SemaphoreSlim _semaphore = new(1);
+
+    private readonly IBackingStorage _storage;
     private readonly Channel<SegmentStatsUpdated> _segmentStatsUpdatedChannel;
     private readonly Channel<OldestObservableSnapshotChanged> _oldestObservableSnapshotChangedChannel;
     private readonly Channel<ChangesWritten> _changesWrittenChannel;
     private readonly Channel<SegmentsCompacted> _segmentsCompactedChannel;
 
+    private readonly PriorityQueue<Segment, VectorClock> _segmentsAwaitingRemoval = new(
+        Comparer<VectorClock>.Create((x, y) =>
+        {
+            var componentComparer = Comparer<long>.Default;
+            var writeComparison = componentComparer.Compare(x.Write, y.Write);
+
+            return writeComparison != 0
+                ? writeComparison
+                : componentComparer.Compare(x.Compaction, y.Compaction);
+        }));
+
     public CompactionActor(
+        IBackingStorage storage,
         Channel<SegmentStatsUpdated> segmentStatsUpdatedChannel,
         Channel<OldestObservableSnapshotChanged> oldestObservableSnapshotChangedChannel,
         Channel<ChangesWritten> changesWrittenChannel,
         Channel<SegmentsCompacted> segmentsCompactedChannel)
     {
+        _storage = storage;
         _segmentStatsUpdatedChannel = segmentStatsUpdatedChannel;
         _oldestObservableSnapshotChangedChannel = oldestObservableSnapshotChangedChannel;
         _changesWrittenChannel = changesWrittenChannel;
@@ -72,6 +89,54 @@ public sealed class CompactionActor
                     //   previous segments.
                     // The ratio of both numbers yields the "efficiency" of compacting a specific candidate range, i.e., by how much
                     // each copied byte will be able to improve the utilization figure.
+
+                    // TODO: Be smart about this, for now we always choose the first two segments as compaction inputs.
+
+                    var sourceStats = message.Stats.Take(2).ToArray();
+                    var minGeneration = sourceStats.First().Key.MinGeneration;
+                    var maxGeneration = sourceStats.Last().Key.MaxGeneration;
+
+                    var compactedClock = message.Clock with
+                    {
+                        Compaction = message.Clock.Compaction + 1,
+                    };
+
+                    // TODO: Compact
+
+                    var compactedSlab = await _storage.CreateSlabAsync();
+                    var compactedSegment = new Segment(minGeneration, maxGeneration, compactedSlab);
+
+                    // WriterActor will complete the "ChangesWritten" channel when the store shuts down,
+                    // so we have to make sure it's still there before writing to it.
+                    while (await _changesWrittenChannel.Writer.WaitToWriteAsync())
+                    {
+                        var succeeded = _changesWrittenChannel.Writer.TryWrite(
+                            new ChangesWritten(
+                                Clock: compactedClock,
+                                Payloads: Array.Empty<KeyValuePair<byte[], SlabSubrange>>(),
+                                Tombstones: new HashSet<byte[]>(),
+                                OutputSegment: compactedSegment
+                            ));
+
+                        if (succeeded)
+                        {
+                            break;
+                        }
+                    }
+
+                    // Cannot delete the source segments right away because there might be active snapshots
+                    // that reference it. Instead, add them to a list and delete them when SnapshotsActor signals
+                    // that no states before the current compaction clock are observable in snapshots anymore.
+                    _segmentsAwaitingRemoval.EnqueueRange(sourceStats.Select(kvp => kvp.Key), compactedClock);
+
+                    // TODO: Tell allocation actor that the store's total capacity has decreased, so that it will
+                    // account for it by making future segments smaller again.
+                    // Note that we can either do this here, OR when the old segments actually get evicted because
+                    // no snapshots reference them anymore.
+                    //await _segmentsCompactedChannel.Writer.WriteAsync(
+                    //    new SegmentsCompacted(
+                    //        Clock: compactedClock,
+                    //        CapacityChange: 0));
                 }
             }
             finally
@@ -90,7 +155,13 @@ public sealed class CompactionActor
 
             try
             {
+                while (_segmentsAwaitingRemoval.TryPeek(out var _, out var compactedAt) && message.Clock.Compaction >= compactedAt.Compaction)
+                {
+                    var segment = _segmentsAwaitingRemoval.Dequeue();
 
+                    // TODO: Ask backing storage to remove it
+                    //await _storage.RemoveSlabAsync(segment.Slab);
+                }
             }
             finally
             {

--- a/src/Fugu.Core/Actors/IndexActor.cs
+++ b/src/Fugu.Core/Actors/IndexActor.cs
@@ -31,6 +31,11 @@ public sealed partial class IndexActor
             var message = await _changesWrittenChannel.Reader.ReadAsync();
             var indexBuilder = _index.ToBuilder();
 
+            // TODO: Figure out how to treat messages that happen due to compactions:
+            // - Ensure updates don't clobber the index by replacing newer payloads.
+            // - Ensure updates reflect properly in segment stats, i.e., stats for compacted source range
+            //   get removed and replaced by stats for compacted output segment instead.
+
             // Process incoming payloads
             foreach (var payload in message.Payloads)
             {

--- a/src/Fugu.Core/Actors/IndexActor.cs
+++ b/src/Fugu.Core/Actors/IndexActor.cs
@@ -8,6 +8,7 @@ namespace Fugu.Actors;
 public sealed partial class IndexActor
 {
     private readonly Channel<ChangesWritten> _changesWrittenChannel;
+    private readonly Channel<CompactionWritten> _compactionWrittenChannel;
     private readonly Channel<IndexUpdated> _indexUpdatedChannel;
     private readonly Channel<SegmentStatsUpdated> _segmentStatsUpdatedChannel;
 
@@ -16,10 +17,12 @@ public sealed partial class IndexActor
 
     public IndexActor(
         Channel<ChangesWritten> changesWrittenChannel,
+        Channel<CompactionWritten> compactionWrittenChannel,
         Channel<IndexUpdated> indexUpdatedChannel,
         Channel<SegmentStatsUpdated> segmentStatsUpdatedChannel)
     {
         _changesWrittenChannel = changesWrittenChannel;
+        _compactionWrittenChannel = compactionWrittenChannel;
         _indexUpdatedChannel = indexUpdatedChannel;
         _segmentStatsUpdatedChannel = segmentStatsUpdatedChannel;
     }

--- a/src/Fugu.Core/Actors/IndexActor.cs
+++ b/src/Fugu.Core/Actors/IndexActor.cs
@@ -70,7 +70,8 @@ public sealed partial class IndexActor
                 await _segmentStatsUpdatedChannel.Writer.WriteAsync(
                     new SegmentStatsUpdated(
                         Clock: message.Clock,
-                        Stats: stats));
+                        Stats: stats,
+                        Index: _index));
             }
         }
 

--- a/src/Fugu.Core/Actors/SnapshotsActor.cs
+++ b/src/Fugu.Core/Actors/SnapshotsActor.cs
@@ -9,8 +9,20 @@ public sealed class SnapshotsActor : ISnapshotOwner
     private readonly SemaphoreSlim _semaphore = new(1);
     private readonly Channel<IndexUpdated> _indexUpdatedChannel;
     private readonly Channel<OldestObservableSnapshotChanged> _oldestObservableSnapshotChangedChannel;
+
     private VectorClock _clock;
     private IReadOnlyDictionary<byte[], IndexEntry> _index = new Dictionary<byte[], IndexEntry>();
+
+    private readonly SortedDictionary<VectorClock, int> _activeSnapshotsByClock = new(
+        Comparer<VectorClock>.Create((x, y) =>
+        {
+            var componentComparer = Comparer<long>.Default;
+            var writeComparison = componentComparer.Compare(x.Write, y.Write);
+
+            return writeComparison != 0
+                ? writeComparison
+                : componentComparer.Compare(x.Compaction, y.Compaction);
+        }));
 
     private readonly PriorityQueue<TaskCompletionSource, VectorClock> _pendingWaiters = new(
         Comparer<VectorClock>.Create((x, y) =>
@@ -98,7 +110,11 @@ public sealed class SnapshotsActor : ISnapshotOwner
 
         try
         {
-            var snapshot = new Snapshot(this, _index);
+            var snapshot = new Snapshot(this, _clock, _index);
+
+            // TODO: Remember this snapshot because we can't remove any segments that can see it
+            _activeSnapshotsByClock[_clock] = _activeSnapshotsByClock.TryGetValue(_clock, out var count) ? count + 1 : 1;
+
             return snapshot;
         }
         finally
@@ -107,8 +123,38 @@ public sealed class SnapshotsActor : ISnapshotOwner
         }
     }
 
-    public void OnSnapshotDisposed(Snapshot snapshot)
+    public async void OnSnapshotDisposed(Snapshot snapshot)
     {
-        // TODO: Implement this
+        await _semaphore.WaitAsync();
+
+        try
+        {
+            // TODO: Remove this snapshot and notify compaction actor we're good to release
+            // any segments that were retained due to being visible in this snapshot
+            var remainingCount = _activeSnapshotsByClock[snapshot.Clock] - 1;
+
+            if (remainingCount == 0)
+            {
+                _activeSnapshotsByClock.Remove(snapshot.Clock);
+
+                // TODO: If dictionary is now empty OR first element is bigger than snapshot's clock value,
+                // notify compaction actor
+                var oldestClock = _activeSnapshotsByClock.Keys.DefaultIfEmpty(_clock).First();
+                if (oldestClock >= snapshot.Clock)
+                {
+                    await _oldestObservableSnapshotChangedChannel.Writer.WriteAsync(
+                        new OldestObservableSnapshotChanged(oldestClock)
+                    );
+                }
+            }
+            else
+            {
+                _activeSnapshotsByClock[snapshot.Clock] = remainingCount;
+            }
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
     }
 }

--- a/src/Fugu.Core/Actors/WriterActor.cs
+++ b/src/Fugu.Core/Actors/WriterActor.cs
@@ -41,7 +41,7 @@ public sealed class WriterActor
             }
 
             // Start new segment if needed
-            _segmentBuilder ??= SegmentBuilder.Create(message.OutputSlab, _outputGeneration, _outputGeneration);
+            _segmentBuilder ??= await SegmentBuilder.CreateAsync(message.OutputSlab, _outputGeneration, _outputGeneration);
 
             var writtenPayloads = await _segmentBuilder.WriteChangeSetAsync(message.ChangeSet);
 

--- a/src/Fugu.Core/Channels/ChangesWritten.cs
+++ b/src/Fugu.Core/Channels/ChangesWritten.cs
@@ -3,8 +3,8 @@
 namespace Fugu.Channels;
 
 /// <summary>
-/// Emitted by <see cref="Actors.WriterActor"/> when a change set has been written to its assigned
-/// output segment.
+/// Emitted by <see cref="Actors.WriterActor"/> or <see cref="Actors.CompactionActor"/> when a change set
+/// or a compacted segment has been written to its associated output segment.
 /// </summary>
 /// <param name="Clock">Logical clock value.</param>
 /// <param name="OutputSegment">Output segment.</param>

--- a/src/Fugu.Core/Channels/CompactionWritten.cs
+++ b/src/Fugu.Core/Channels/CompactionWritten.cs
@@ -1,0 +1,9 @@
+﻿using Fugu.Utils;
+
+namespace Fugu.Channels;
+
+public readonly record struct CompactionWritten(
+    VectorClock Clock,
+    Segment OutputSegment,
+    ChangeSetCoordinates Changes
+);

--- a/src/Fugu.Core/Channels/OldestObservableSnapshotChanged.cs
+++ b/src/Fugu.Core/Channels/OldestObservableSnapshotChanged.cs
@@ -1,0 +1,7 @@
+﻿using Fugu.Utils;
+
+namespace Fugu.Channels;
+
+public readonly record struct OldestObservableSnapshotChanged(
+    VectorClock Clock
+);

--- a/src/Fugu.Core/Channels/SegmentStatsUpdated.cs
+++ b/src/Fugu.Core/Channels/SegmentStatsUpdated.cs
@@ -8,7 +8,9 @@ namespace Fugu.Channels;
 /// </summary>
 /// <param name="Clock">Logical clock value.</param>
 /// <param name="Stats">Usage stats for all segments part of the index.</param>
+/// <param name="Index">State of the index at the given clock value.</param>
 public readonly record struct SegmentStatsUpdated(
     VectorClock Clock,
-    IReadOnlyDictionary<Segment, SegmentStats> Stats
+    IReadOnlyDictionary<Segment, SegmentStats> Stats,
+    IReadOnlyDictionary<byte[], IndexEntry> Index
 );

--- a/src/Fugu.Core/Channels/SegmentsCompacted.cs
+++ b/src/Fugu.Core/Channels/SegmentsCompacted.cs
@@ -1,14 +1,10 @@
-﻿using Fugu.Utils;
-
-namespace Fugu.Channels;
+﻿namespace Fugu.Channels;
 
 /// <summary>
 /// Emitted by <see cref="Actors.CompactionActor"/> when two or more segments have been compacted to
 /// re-balance the store, resulting in a reduction in idealized store capacity.
 /// </summary>
-/// <param name="Clock">Logical clock value.</param>
 /// <param name="CapacityChange">Net change to idealized store capacity; typically negative.</param>
 public readonly record struct SegmentsCompacted(
-    VectorClock Clock,
     long CapacityChange
 );

--- a/src/Fugu.Core/Channels/SegmentsCompacted.cs
+++ b/src/Fugu.Core/Channels/SegmentsCompacted.cs
@@ -1,0 +1,14 @@
+﻿using Fugu.Utils;
+
+namespace Fugu.Channels;
+
+/// <summary>
+/// Emitted by <see cref="Actors.CompactionActor"/> when two or more segments have been compacted to
+/// re-balance the store, resulting in a reduction in idealized store capacity.
+/// </summary>
+/// <param name="Clock">Logical clock value.</param>
+/// <param name="CapacityChange">Net change to idealized store capacity; typically negative.</param>
+public readonly record struct SegmentsCompacted(
+    VectorClock Clock,
+    long CapacityChange
+);

--- a/src/Fugu.Core/IO/Bootstrapper.cs
+++ b/src/Fugu.Core/IO/Bootstrapper.cs
@@ -1,8 +1,4 @@
 ﻿using Fugu.Channels;
-using Fugu.Utils;
-using System.Buffers;
-using System.Collections.Immutable;
-using System.IO.Pipelines;
 using System.Threading.Channels;
 
 namespace Fugu.IO;
@@ -13,26 +9,25 @@ public static class Bootstrapper
         IBackingStorage storage, Channel<ChangesWritten> changesWrittenChannel)
     {
         var slabs = await storage.GetAllSlabsAsync();
-        var segments = new List<Segment>(capacity: slabs.Count);
+        var segmentParsers = new List<SegmentParser>(capacity: slabs.Count);
 
         foreach (var slab in slabs)
         {
-            var segment = await ReadSegmentHeaderAsync(slab);
-            segments.Add(segment);
+			segmentParsers.Add(await SegmentParser.CreateAsync(slab));
         }
 
         // Order segments, decide on which ones to load & which ones to skip
         // TODO: The current implementation assumes that generations will never overlap, hence comparing MinGeneration
         // is sufficient to establish proper ordering. This assumption will NO LONGER BE VALID once we implement compaction.
-        segments.Sort((x, y) => Comparer<long>.Default.Compare(x.MinGeneration, y.MinGeneration));
+        segmentParsers.Sort((x, y) => Comparer<long>.Default.Compare(x.Segment.MinGeneration, y.Segment.MinGeneration));
 
-        long maxGeneration = segments.Count > 0 ? segments.Max(s => s.MaxGeneration) : 0;
+        long maxGeneration = segmentParsers.Count > 0 ? segmentParsers.Max(s => s.Segment.MaxGeneration) : 0;
         long totalBytes = 0;
 
         // For all change sets across all segments in order, feed these change sets to index actor
-        foreach (var segment in segments)
+        foreach (var parser in segmentParsers)
         {
-            await foreach (var changeSet in ReadChangeSetsAsync(segment))
+            await foreach (var changeSet in parser.ReadChangeSetsAsync())
             {
                 totalBytes += changeSet.Payloads.Sum(p => p.Key.Length + p.Value.Length) + changeSet.Tombstones.Sum(t => t.Length);
                 await changesWrittenChannel.Writer.WriteAsync(changeSet);
@@ -40,211 +35,5 @@ public static class Bootstrapper
         }
 
         return new BootstrapResult(maxGeneration, totalBytes);
-    }
-
-    private static async Task<Segment> ReadSegmentHeaderAsync(ISlab slab)
-    {
-        if (slab.Length < StorageFormat.SegmentHeaderSize)
-        {
-            throw new InvalidOperationException("Slab too small to contain segment header.");
-        }
-
-        var headerBytes = new byte[StorageFormat.SegmentHeaderSize];
-        await slab.ReadAsync(headerBytes, 0);
-        return ParseSegmentHeader(headerBytes);
-
-        Segment ParseSegmentHeader(byte[] headerBytes)
-        {
-            var segmentReader = new SegmentReader(new ReadOnlySequence<byte>(headerBytes));
-            segmentReader.TryReadSegmentHeader(out var minGeneration, out var maxGeneration);
-            return new Segment(minGeneration, maxGeneration, slab);
-        }
-    }
-
-    // This level knows the segment, constructs the PipeReader, and tracks authoritative offset in the
-    // segment while reading. Therefore, its job is to yield a sequence of channel messages that can
-    // be readily submitted to the index actor.
-    private static async IAsyncEnumerable<ChangesWritten> ReadChangeSetsAsync(Segment segment)
-    {
-        // Create PipeReader for segment contents beyond header
-        PipeReader pipeReader = await GetChangeSetPipeReaderAsync(segment.Slab);
-        long offset = StorageFormat.SegmentHeaderSize;
-
-        while (true)
-        {
-            var parseContext = new ChangeSetParseContext();
-            ReadResult readResult;
-
-            do
-            {
-                readResult = await pipeReader.ReadAsync();
-                var consumed = ParseChangeSetCore(ref parseContext, offset, readResult);
-                var consumedPosition = readResult.Buffer.GetPosition(consumed);
-
-                offset += consumed;
-
-                // TODO: if parseContext signals that change set has been fully read, then:
-                // 1. advance pipeReader to "consumed" position, but do NOT mark rest of buffer as examined;
-                // 2. construct WrittenChanges struct (without segment) from parseContext and return that,
-                //    thus breaking from the loop.
-                if (parseContext.Current == ChangeSetParseToken.Completed)
-                {
-                    pipeReader.AdvanceTo(consumedPosition);
-                    break;
-                }
-
-                // Otherwise, we need more data in the buffer to make progress. Mark buffer contents as fully examined
-                // to tell PipeReader.ReadAsync that we need more data.
-                pipeReader.AdvanceTo(consumedPosition, examined: readResult.Buffer.End);
-            }
-            while (!readResult.IsCompleted);
-
-            if (parseContext.Current == ChangeSetParseToken.ChangeSetHeader)
-            {
-                // Parsing failed to even read a change set header? We're done here.
-                break;
-            }
-            else if (parseContext.Current == ChangeSetParseToken.Completed)
-            {
-                // Parsing completed a full change set? Return it.
-                var payloads = Enumerable.Zip(
-                    parseContext.PayloadKeys,
-                    parseContext.PayloadValues,
-                    (k, v) => new KeyValuePair<byte[], SlabSubrange>(k, v)).ToArray();
-
-                yield return new ChangesWritten(
-                    new VectorClock(0, 0),
-                    segment,
-                    payloads,
-                    parseContext.Tombstones.ToImmutableHashSet());
-            }
-            else
-            {
-                // Otherwise, parsing aborted in the middle of a change set. Something went wrong.
-                throw new InvalidOperationException("Reading aborted before change set was completed.");
-            }
-        }
-    }
-
-    private static async ValueTask<PipeReader> GetChangeSetPipeReaderAsync(ISlab slab)
-    {
-        // TODO: this implementation reads the entire slab in one go. This won't work if the slab is larger
-        // than 4 GB, in which case it'll need to read chunk-by-chunk.
-        var buffer = new byte[slab.Length - StorageFormat.SegmentHeaderSize];
-        await slab.ReadAsync(buffer, StorageFormat.SegmentHeaderSize);
-        return PipeReader.Create(new ReadOnlySequence<byte>(buffer));
-    }
-
-    private static long ParseChangeSetCore(ref ChangeSetParseContext parseContext, long offset, ReadResult readResult)
-    {
-        var segmentReader = new SegmentReader(readResult.Buffer);
-
-        // Based on current parse state, try to pull the corresponding structure from segmentReader & update parse state if
-        // successful. If unsuccessful, don't update parse state but return segmentReader.Position instead to signal that
-        // we need more data to proceed.
-        while (parseContext.Current != ChangeSetParseToken.Completed)
-        {
-            switch (parseContext.Current)
-            {
-                case ChangeSetParseToken.ChangeSetHeader:
-                    {
-                        if (!segmentReader.TryReadChangeSetHeader(out var payloadCount, out var tombstoneCount))
-                        {
-                            return segmentReader.Consumed;
-                        }
-
-                        parseContext.Current = ChangeSetParseToken.Tombstones;
-                        parseContext.RemainingPayloads = payloadCount;
-                        parseContext.RemainingTombstones = tombstoneCount;
-                        parseContext.Tombstones = new List<byte[]>(capacity: tombstoneCount);
-                        parseContext.PayloadKeys = new List<byte[]>(capacity: payloadCount);
-                        parseContext.PayloadValues = new List<SlabSubrange>(capacity: payloadCount);
-                        parseContext.PayloadValueLengths = new Queue<int>(capacity: payloadCount);
-
-                        break;
-                    }
-
-                case ChangeSetParseToken.Tombstones:
-                    {
-                        while (parseContext.RemainingTombstones > 0)
-                        {
-                            if (!segmentReader.TryReadTombstone(out var key))
-                            {
-                                return segmentReader.Consumed;
-                            }
-
-                            parseContext.Tombstones.Add(key);
-                            parseContext.RemainingTombstones--;
-                        }
-
-                        parseContext.Current = ChangeSetParseToken.PayloadHeaders;
-                        break;
-                    }
-
-                case ChangeSetParseToken.PayloadHeaders:
-                    {
-                        while (parseContext.RemainingPayloads > 0)
-                        {
-                            if (!segmentReader.TryReadPayloadHeader(out var key, out var valueLength))
-                            {
-                                return segmentReader.Consumed;
-                            }
-
-                            parseContext.PayloadKeys.Add(key);
-                            parseContext.PayloadValueLengths.Enqueue(valueLength);
-                            parseContext.RemainingPayloads--;
-                        }
-
-                        parseContext.Current = ChangeSetParseToken.PayloadValues;
-                        break;
-                    }
-
-                case ChangeSetParseToken.PayloadValues:
-                    {
-                        while (parseContext.PayloadValueLengths.TryPeek(out var valueLength))
-                        {
-                            var valueOffset = offset + segmentReader.Consumed;
-
-                            if (!segmentReader.TryAdvancePastPayloadValue(valueLength))
-                            {
-                                return segmentReader.Consumed;
-                            }
-
-                            parseContext.PayloadValueLengths.Dequeue();
-
-                            var payloadValue = new SlabSubrange(valueOffset, valueLength);
-                            parseContext.PayloadValues.Add(payloadValue);
-                        }
-
-                        parseContext.Current = ChangeSetParseToken.Completed;
-                        break;
-                    }
-
-                default:
-                    throw new InvalidOperationException();
-            }
-        }
-
-        return segmentReader.Consumed;
-    }
-
-    private struct ChangeSetParseContext
-    {
-        public ChangeSetParseToken Current;
-        public int RemainingPayloads;
-        public int RemainingTombstones;
-        public List<byte[]> Tombstones;
-        public List<byte[]> PayloadKeys;
-        public List<SlabSubrange> PayloadValues;
-        public Queue<int> PayloadValueLengths;
-    }
-
-    private enum ChangeSetParseToken : byte
-    {
-        ChangeSetHeader = default,
-        PayloadHeaders,
-        Tombstones,
-        PayloadValues,
-        Completed,
     }
 }

--- a/src/Fugu.Core/IO/InMemorySlab.cs
+++ b/src/Fugu.Core/IO/InMemorySlab.cs
@@ -40,6 +40,11 @@ public class InMemorySlab : IWritableSlab, ISlab
 
         try
         {
+            if (offset > _arrayBufferWriter.WrittenCount)
+            {
+                throw new InvalidOperationException("Attempted to read from offset past the end of the slab.");
+            }
+
             var availableBytes = Math.Min(buffer.Length, _arrayBufferWriter.WrittenCount - (int)offset);
             var slice = _arrayBufferWriter.WrittenSpan.Slice((int)offset, availableBytes);
             slice.CopyTo(buffer.Span);

--- a/src/Fugu.Core/IO/SegmentBuilder.cs
+++ b/src/Fugu.Core/IO/SegmentBuilder.cs
@@ -1,0 +1,77 @@
+﻿using Fugu.Utils;
+using System.Buffers;
+using System.IO.Pipelines;
+
+namespace Fugu.IO;
+
+/// <summary>
+/// Provides a high level interface to create a segment from a series of individual ChangeSets.
+/// </summary>
+public sealed class SegmentBuilder
+{
+    private readonly PipeWriter _pipeWriter;
+    private long _offset;
+
+    private SegmentBuilder(Segment segment, PipeWriter pipeWriter, long initialOffset)
+    {
+        Segment = segment;
+        _pipeWriter = pipeWriter;
+        _offset = initialOffset;
+    }
+
+    public Segment Segment { get; }
+
+    public static SegmentBuilder Create(IWritableSlab outputSlab, long minGeneration, long maxGeneration)
+    {
+        var segment = new Segment(minGeneration, maxGeneration, outputSlab);
+        var pipeWriter = PipeWriter.Create(outputSlab.Output);
+        var segmentWriter = new SegmentWriter(pipeWriter);
+
+        segmentWriter.WriteSegmentHeader(segment.MinGeneration, segment.MaxGeneration);
+
+        return new SegmentBuilder(segment, pipeWriter, segmentWriter.BytesWritten);
+    }
+
+    public ValueTask CompleteAsync()
+    {
+        return _pipeWriter.CompleteAsync();
+    }
+
+    public async ValueTask<IReadOnlyList<KeyValuePair<byte[], SlabSubrange>>> WriteChangeSetAsync(ChangeSet changeSet)
+    {
+        var changesWritten = WriteChangeSet(changeSet);
+        await _pipeWriter.FlushAsync();
+        return changesWritten;
+    }
+
+    private List<KeyValuePair<byte[], SlabSubrange>> WriteChangeSet(ChangeSet changeSet)
+    {
+        var segmentWriter = new SegmentWriter(_pipeWriter);
+        segmentWriter.WriteChangeSetHeader(changeSet.Payloads.Count, changeSet.Tombstones.Count);
+
+        foreach (var tombstone in changeSet.Tombstones)
+        {
+            segmentWriter.WriteTombstone(tombstone);
+        }
+
+        var payloads = changeSet.Payloads.ToArray();
+        var writtenPayloads = new List<KeyValuePair<byte[], SlabSubrange>>(payloads.Length);
+
+        foreach (var payload in payloads)
+        {
+            segmentWriter.WritePayloadHeader(payload.Key, payload.Value.Length);
+        }
+
+        _offset += segmentWriter.BytesWritten;
+
+        foreach (var payload in payloads)
+        {
+            _pipeWriter.Write(payload.Value.Span);
+
+            writtenPayloads.Add(new(payload.Key, new(_offset, payload.Value.Length)));
+            _offset += payload.Value.Length;
+        }
+
+        return writtenPayloads;
+    }
+}

--- a/src/Fugu.Core/IO/SegmentParser.cs
+++ b/src/Fugu.Core/IO/SegmentParser.cs
@@ -1,0 +1,224 @@
+﻿using Fugu.Channels;
+using Fugu.Utils;
+using System.Buffers;
+using System.Collections.Immutable;
+using System.IO.Pipelines;
+
+namespace Fugu.IO;
+
+public sealed class SegmentParser
+{
+    private SegmentParser(Segment segment)
+    {
+        Segment = segment;
+    }
+
+    public Segment Segment { get; }
+
+    public static async Task<SegmentParser> CreateAsync(ISlab slab)
+    {
+		var headerBytes = new byte[StorageFormat.SegmentHeaderSize];
+		await slab.ReadAsync(headerBytes, 0);
+		var segment = ReadSegmentHeader(headerBytes, slab);
+        return new SegmentParser(segment);
+
+		Segment ReadSegmentHeader(byte[] headerBytes, ISlab slab)
+		{
+			if (slab.Length < StorageFormat.SegmentHeaderSize)
+			{
+				throw new InvalidOperationException("Slab too small to contain segment header.");
+			}
+
+			var segmentReader = new SegmentReader(new ReadOnlySequence<byte>(headerBytes));
+			if (!segmentReader.TryReadSegmentHeader(out var minGeneration, out var maxGeneration))
+			{
+				throw new InvalidOperationException("Failed to read segment header.");
+			}
+
+			return new Segment(minGeneration, maxGeneration, slab);
+		}
+	}
+
+	public async IAsyncEnumerable<ChangesWritten> ReadChangeSetsAsync()
+	{
+		var pipeReader = await GetPipeReaderPastHeaderAsync();
+		long offset = StorageFormat.SegmentHeaderSize;
+
+		while (true)
+		{
+			var parseContext = new ChangeSetParseContext();
+			ReadResult readResult;
+
+			do
+			{
+				readResult = await pipeReader.ReadAsync();
+				var consumed = ParseChangeSetCore(ref parseContext, offset, readResult);
+				var consumedPosition = readResult.Buffer.GetPosition(consumed);
+
+				offset += consumed;
+
+				// TODO: if parseContext signals that change set has been fully read, then:
+				// 1. advance pipeReader to "consumed" position, but do NOT mark rest of buffer as examined;
+				// 2. construct WrittenChanges struct (without segment) from parseContext and return that,
+				//    thus breaking from the loop.
+				if (parseContext.Current == ChangeSetParseToken.Completed)
+				{
+					pipeReader.AdvanceTo(consumedPosition);
+					break;
+				}
+
+				// Otherwise, we need more data in the buffer to make progress. Mark buffer contents as fully examined
+				// to tell PipeReader.ReadAsync that we need more data.
+				pipeReader.AdvanceTo(consumedPosition, examined: readResult.Buffer.End);
+			}
+			while (!readResult.IsCompleted);
+
+			if (parseContext.Current == ChangeSetParseToken.ChangeSetHeader)
+			{
+				// Parsing failed to even read a change set header? We're done here.
+				break;
+			}
+			else if (parseContext.Current == ChangeSetParseToken.Completed)
+			{
+				// Parsing completed a full change set? Return it.
+				var payloads = Enumerable.Zip(
+					parseContext.PayloadKeys,
+					parseContext.PayloadValues,
+					(k, v) => new KeyValuePair<byte[], SlabSubrange>(k, v)).ToArray();
+
+				yield return new ChangesWritten(
+					new VectorClock(0, 0),
+					Segment,
+					payloads,
+					parseContext.Tombstones.ToImmutableHashSet());
+			}
+			else
+			{
+				// Otherwise, parsing aborted in the middle of a change set. Something went wrong.
+				throw new InvalidOperationException("Reading aborted before change set was completed.");
+			}
+		}
+	}
+
+	private async ValueTask<PipeReader> GetPipeReaderPastHeaderAsync()
+	{
+		// TODO: this implementation reads the entire slab in one go. This won't work if the slab is larger
+		// than 4 GB, in which case it'll need to read chunk-by-chunk.
+		var buffer = new byte[Segment.Slab.Length - StorageFormat.SegmentHeaderSize];
+		await Segment.Slab.ReadAsync(buffer, StorageFormat.SegmentHeaderSize);
+		return PipeReader.Create(new ReadOnlySequence<byte>(buffer));
+	}
+
+	private static long ParseChangeSetCore(ref ChangeSetParseContext parseContext, long offset, ReadResult readResult)
+	{
+		var segmentReader = new SegmentReader(readResult.Buffer);
+
+		// Based on current parse state, try to pull the corresponding structure from segmentReader & update parse state if
+		// successful. If unsuccessful, don't update parse state but return segmentReader.Position instead to signal that
+		// we need more data to proceed.
+		while (parseContext.Current != ChangeSetParseToken.Completed)
+		{
+			switch (parseContext.Current)
+			{
+				case ChangeSetParseToken.ChangeSetHeader:
+					{
+						if (!segmentReader.TryReadChangeSetHeader(out var payloadCount, out var tombstoneCount))
+						{
+							return segmentReader.Consumed;
+						}
+
+						parseContext.Current = ChangeSetParseToken.Tombstones;
+						parseContext.RemainingPayloads = payloadCount;
+						parseContext.RemainingTombstones = tombstoneCount;
+						parseContext.Tombstones = new List<byte[]>(capacity: tombstoneCount);
+						parseContext.PayloadKeys = new List<byte[]>(capacity: payloadCount);
+						parseContext.PayloadValues = new List<SlabSubrange>(capacity: payloadCount);
+						parseContext.PayloadValueLengths = new Queue<int>(capacity: payloadCount);
+
+						break;
+					}
+
+				case ChangeSetParseToken.Tombstones:
+					{
+						while (parseContext.RemainingTombstones > 0)
+						{
+							if (!segmentReader.TryReadTombstone(out var key))
+							{
+								return segmentReader.Consumed;
+							}
+
+							parseContext.Tombstones.Add(key);
+							parseContext.RemainingTombstones--;
+						}
+
+						parseContext.Current = ChangeSetParseToken.PayloadHeaders;
+						break;
+					}
+
+				case ChangeSetParseToken.PayloadHeaders:
+					{
+						while (parseContext.RemainingPayloads > 0)
+						{
+							if (!segmentReader.TryReadPayloadHeader(out var key, out var valueLength))
+							{
+								return segmentReader.Consumed;
+							}
+
+							parseContext.PayloadKeys.Add(key);
+							parseContext.PayloadValueLengths.Enqueue(valueLength);
+							parseContext.RemainingPayloads--;
+						}
+
+						parseContext.Current = ChangeSetParseToken.PayloadValues;
+						break;
+					}
+
+				case ChangeSetParseToken.PayloadValues:
+					{
+						while (parseContext.PayloadValueLengths.TryPeek(out var valueLength))
+						{
+							var valueOffset = offset + segmentReader.Consumed;
+
+							if (!segmentReader.TryAdvancePastPayloadValue(valueLength))
+							{
+								return segmentReader.Consumed;
+							}
+
+							parseContext.PayloadValueLengths.Dequeue();
+
+							var payloadValue = new SlabSubrange(valueOffset, valueLength);
+							parseContext.PayloadValues.Add(payloadValue);
+						}
+
+						parseContext.Current = ChangeSetParseToken.Completed;
+						break;
+					}
+
+				default:
+					throw new InvalidOperationException();
+			}
+		}
+
+		return segmentReader.Consumed;
+	}
+
+	private struct ChangeSetParseContext
+	{
+		public ChangeSetParseToken Current;
+		public int RemainingPayloads;
+		public int RemainingTombstones;
+		public List<byte[]> Tombstones;
+		public List<byte[]> PayloadKeys;
+		public List<SlabSubrange> PayloadValues;
+		public Queue<int> PayloadValueLengths;
+	}
+
+	private enum ChangeSetParseToken : byte
+	{
+		ChangeSetHeader = default,
+		PayloadHeaders,
+		Tombstones,
+		PayloadValues,
+		Completed,
+	}
+}

--- a/src/Fugu.Core/IO/SegmentParser.cs
+++ b/src/Fugu.Core/IO/SegmentParser.cs
@@ -39,7 +39,7 @@ public sealed class SegmentParser
 		}
 	}
 
-	public async IAsyncEnumerable<ChangesWritten> ReadChangeSetsAsync()
+	public async IAsyncEnumerable<ChangeSetCoordinates> ReadChangeSetsAsync()
 	{
 		var pipeReader = await GetPipeReaderPastHeaderAsync();
 		long offset = StorageFormat.SegmentHeaderSize;
@@ -86,11 +86,7 @@ public sealed class SegmentParser
 					parseContext.PayloadValues,
 					(k, v) => new KeyValuePair<byte[], SlabSubrange>(k, v)).ToArray();
 
-				yield return new ChangesWritten(
-					new VectorClock(0, 0),
-					Segment,
-					payloads,
-					parseContext.Tombstones.ToImmutableHashSet());
+				yield return new ChangeSetCoordinates(payloads, parseContext.Tombstones);
 			}
 			else
 			{

--- a/src/Fugu.Core/KeyValueStore.cs
+++ b/src/Fugu.Core/KeyValueStore.cs
@@ -87,6 +87,7 @@ public sealed class KeyValueStore : IAsyncDisposable
         var allocationActor = new AllocationActor(storage, segmentsCompactedChannel, changeSetAllocatedChannel, bootstrapResult.TotalBytes);
         var writerActor = new WriterActor(changeSetAllocatedChannel, changesWrittenChannel, bootstrapResult.MaxGeneration);
         var compactionActor = new CompactionActor(
+            storage,
             segmentStatsUpdatedChannel,
             oldestObservableSnapshotChangedChannel,
             changesWrittenChannel,

--- a/src/Fugu.Core/KeyValueStore.cs
+++ b/src/Fugu.Core/KeyValueStore.cs
@@ -35,35 +35,62 @@ public sealed class KeyValueStore : IAsyncDisposable
         var changeSetAllocatedChannel = Channel.CreateUnbounded<ChangeSetAllocated>(new UnboundedChannelOptions
         {
             AllowSynchronousContinuations = true,
+            SingleWriter = true,
+            SingleReader = true,
         });
 
         var changesWrittenChannel = Channel.CreateUnbounded<ChangesWritten>(new UnboundedChannelOptions
         {
             AllowSynchronousContinuations = true,
+            SingleWriter = false,
+            SingleReader = true,
         });
 
         var indexUpdatedChannel = Channel.CreateUnbounded<IndexUpdated>(new UnboundedChannelOptions
         {
             AllowSynchronousContinuations = true,
+            SingleWriter = true,
+            SingleReader = true,
         });
 
         var segmentStatsUpdatedChannel = Channel.CreateBounded<SegmentStatsUpdated>(new BoundedChannelOptions(1)
         {
             AllowSynchronousContinuations = false,
             FullMode = BoundedChannelFullMode.DropNewest,
+            SingleWriter = true,
+            SingleReader = true,
+        });
+
+        var oldestObservableSnapshotChangedChannel = Channel.CreateBounded<OldestObservableSnapshotChanged>(new BoundedChannelOptions(1)
+        {
+            AllowSynchronousContinuations = false,
+            FullMode = BoundedChannelFullMode.DropNewest,
+            SingleWriter = true,
+            SingleReader = true,
+        });
+
+        var segmentsCompactedChannel = Channel.CreateUnbounded<SegmentsCompacted>(new UnboundedChannelOptions
+        {
+            AllowSynchronousContinuations = false,
+            SingleWriter = true,
+            SingleReader = true,
         });
 
         // Create actors involved in bootstrapping
         var indexActor = new IndexActor(changesWrittenChannel, indexUpdatedChannel, segmentStatsUpdatedChannel);
-        var snapshotsActor = new SnapshotsActor(indexUpdatedChannel);
+        var snapshotsActor = new SnapshotsActor(indexUpdatedChannel, oldestObservableSnapshotChangedChannel);
 
         // Load existing data
         var bootstrapResult = await Bootstrapper.LoadFromStorageAsync(storage, changesWrittenChannel);
 
         // Create actors involved in writes and balancing
-        var allocationActor = new AllocationActor(storage, changeSetAllocatedChannel, bootstrapResult.TotalBytes);
+        var allocationActor = new AllocationActor(storage, segmentsCompactedChannel, changeSetAllocatedChannel, bootstrapResult.TotalBytes);
         var writerActor = new WriterActor(changeSetAllocatedChannel, changesWrittenChannel, bootstrapResult.MaxGeneration);
-        var compactionActor = new CompactionActor(segmentStatsUpdatedChannel);
+        var compactionActor = new CompactionActor(
+            segmentStatsUpdatedChannel,
+            oldestObservableSnapshotChangedChannel,
+            changesWrittenChannel,
+            segmentsCompactedChannel);
 
         var store = new KeyValueStore(
             allocationActor,

--- a/src/Fugu.Core/Snapshot.cs
+++ b/src/Fugu.Core/Snapshot.cs
@@ -8,11 +8,17 @@ public sealed class Snapshot : IDisposable
     private readonly ISnapshotOwner _owner;
     private readonly IReadOnlyDictionary<byte[], IndexEntry> _index;
 
-    internal Snapshot(ISnapshotOwner owner, IReadOnlyDictionary<byte[], IndexEntry> index)
+    internal Snapshot(
+        ISnapshotOwner owner,
+        VectorClock clock,
+        IReadOnlyDictionary<byte[], IndexEntry> index)
     {
         _owner = owner;
+        Clock = clock;
         _index = index;
     }
+    
+    public VectorClock Clock { get; }
 
     public IEnumerable<IReadOnlyList<byte>> Keys => _index.Keys;
 

--- a/src/Fugu.Core/Utils/ChangeSetCoordinates.cs
+++ b/src/Fugu.Core/Utils/ChangeSetCoordinates.cs
@@ -1,0 +1,12 @@
+﻿namespace Fugu.Utils;
+
+/// <summary>
+/// Represents payloads and tombstones of a change set that has been persisted
+/// to a segment in backing storage.
+/// </summary>
+/// <param name="Payloads">Payload keys and value offsets/lengths in the associated segment.</param>
+/// <param name="Tombstones">Tombstone keys.</param>
+public readonly record struct ChangeSetCoordinates(
+	IReadOnlyList<KeyValuePair<byte[], SlabSubrange>> Payloads,
+	IReadOnlyList<byte[]> Tombstones
+);

--- a/src/Fugu.Core/Utils/ChangeSetUtils.cs
+++ b/src/Fugu.Core/Utils/ChangeSetUtils.cs
@@ -6,4 +6,9 @@ internal static class ChangeSetUtils
     {
         return changeSet.Payloads.Sum(p => p.Key.Length + p.Value.Length) + changeSet.Tombstones.Sum(t => t.Length);
     }
+
+    public static long GetDataBytes(ChangeSetCoordinates changeSet)
+    {
+        return changeSet.Payloads.Sum(p => p.Key.Length + p.Value.Length) + changeSet.Tombstones.Sum(t => t.Length);
+    }
 }

--- a/src/Fugu.Core/Utils/SegmentStatsBuilder.cs
+++ b/src/Fugu.Core/Utils/SegmentStatsBuilder.cs
@@ -1,0 +1,52 @@
+﻿namespace Fugu.Utils;
+
+public sealed class SegmentStatsBuilder
+{
+    // Track unique keys of payloads that appear in the associated segment. When the segment has been completed,
+    // these keys may require that tombstones in following segments cannot be flushed out during compaction,
+    // because they must continue to suppress this payload.
+    private readonly HashSet<byte[]> _payloadKeys = new(ByteArrayEqualityComparer.Shared);
+    private SegmentStats _stats = new();
+
+    public SegmentStatsBuilder(Segment segment)
+    {
+        Segment = segment;
+    }
+
+    public Segment Segment { get; }
+    public HashSet<byte[]> PayloadKeys => _payloadKeys;
+    public SegmentStats Stats => _stats;
+
+    public void OnPayloadAdded(KeyValuePair<byte[], SlabSubrange> payload)
+    {
+        var byteCount = payload.Key.Length + payload.Value.Length;
+        _stats = _stats with
+        {
+            TotalBytes = _stats.TotalBytes + byteCount,
+        };
+
+        _payloadKeys.Add(payload.Key);
+    }
+
+    public void OnTombstoneAdded(byte[] tombstone)
+    {
+        var byteCount = tombstone.Length;
+        _stats = _stats with
+        {
+            TotalBytes = _stats.TotalBytes + byteCount,
+            StaleBytes = _stats.StaleBytes + byteCount,
+        };
+    }
+
+    public void OnPayloadDisplaced(KeyValuePair<byte[], SlabSubrange> payload)
+    {
+        if (_payloadKeys.Remove(payload.Key))
+        {
+            var byteCount = payload.Key.Length + payload.Value.Length;
+            _stats = _stats with
+            {
+                StaleBytes = _stats.StaleBytes + byteCount,
+            };
+        }
+    }
+}

--- a/src/Fugu.Core/Utils/SegmentStatsTracker.cs
+++ b/src/Fugu.Core/Utils/SegmentStatsTracker.cs
@@ -47,7 +47,19 @@ public sealed class SegmentStatsTracker
             .TakeWhile(s => s.MaxGeneration <= builder.Segment.MaxGeneration)
             .ToArray();
 
-        _statsBuilder.RemoveRange(replaced);
+        if (replaced.Length > 0)
+        {
+            // Verify the before/after re. live bytes are equal
+            var liveBytesBeforeCompaction = replaced.Sum(s => _statsBuilder[s].LiveBytes);
+            var liveBytesAfterCompaction = builder.Stats.LiveBytes;
+
+            if (liveBytesBeforeCompaction != liveBytesAfterCompaction)
+            {
+                throw new InvalidOperationException();
+            }
+
+            _statsBuilder.RemoveRange(replaced);
+        }
 
         _statsBuilder[builder.Segment] = builder.Stats;
     }

--- a/src/Fugu.Core/Utils/SegmentStatsTracker.cs
+++ b/src/Fugu.Core/Utils/SegmentStatsTracker.cs
@@ -5,8 +5,6 @@ namespace Fugu.Utils;
 public sealed class SegmentStatsTracker
 {
     private readonly ImmutableSortedDictionary<Segment, SegmentStats>.Builder _statsBuilder;
-    private Segment? _outputSegment = null;
-    private SegmentStats _outputSegmentStats = new();
 
     public SegmentStatsTracker()
     {
@@ -32,61 +30,25 @@ public sealed class SegmentStatsTracker
     public void OnIndexEntryDisplaced(byte[] key, IndexEntry indexEntry)
     {
         var byteCount = key.Length + indexEntry.Subrange.Length;
+        var stats = _statsBuilder[indexEntry.Segment];
 
-        if (indexEntry.Segment == _outputSegment)
+        _statsBuilder[indexEntry.Segment] = stats with
         {
-            _outputSegmentStats = _outputSegmentStats with
-            {
-                StaleBytes = _outputSegmentStats.StaleBytes + byteCount,
-            };
-        }
-        else
-        {
-            var stats = _statsBuilder[indexEntry.Segment];
-
-            _statsBuilder[indexEntry.Segment] = stats with
-            {
-                StaleBytes = stats.StaleBytes + byteCount,
-            };
-        }
-    }
-
-    public void OnPayloadAdded(Segment segment, KeyValuePair<byte[], SlabSubrange> payload)
-    {
-        UseOutputSegment(segment);
-
-        var byteCount = payload.Key.Length + payload.Value.Length;
-        _outputSegmentStats = _outputSegmentStats with
-        {
-            TotalBytes = _outputSegmentStats.TotalBytes + byteCount,
+            StaleBytes = stats.StaleBytes + byteCount,
         };
     }
 
-    public void OnTombstoneAdded(Segment segment, byte[] tombstone)
+    public void Add(SegmentStatsBuilder builder)
     {
-        UseOutputSegment(segment);
+        // Drop any current entries that are within the range of generations covered by builder.Segment.
+        // This will happen only when merging a compacted segment.
+        var replaced = _statsBuilder.Keys
+            .SkipWhile(s => s.MinGeneration < builder.Segment.MinGeneration)
+            .TakeWhile(s => s.MaxGeneration <= builder.Segment.MaxGeneration)
+            .ToArray();
 
-        var byteCount = tombstone.Length;
-        _outputSegmentStats = _outputSegmentStats with
-        {
-            TotalBytes = _outputSegmentStats.TotalBytes + byteCount,
-            StaleBytes = _outputSegmentStats.StaleBytes + byteCount,
-        };
-    }
+        _statsBuilder.RemoveRange(replaced);
 
-    private void UseOutputSegment(Segment segment)
-    {
-        if (_outputSegment == segment)
-        {
-            return;
-        }
-
-        if (_outputSegment is not null)
-        {
-            _statsBuilder[_outputSegment] = _outputSegmentStats;
-        }
-
-        _outputSegment = segment;
-        _outputSegmentStats = new();
+        _statsBuilder[builder.Segment] = builder.Stats;
     }
 }

--- a/tests/Fugu.Core.Tests/SegmentStatsTrackerTests.cs
+++ b/tests/Fugu.Core.Tests/SegmentStatsTrackerTests.cs
@@ -5,47 +5,47 @@ namespace Fugu.Core.Tests;
 
 public class SegmentStatsTrackerTests
 {
-    [Fact]
-    public async Task OnPayloadAdded_DoesNotImmediatelyReflectInStats()
-    {
-        var tracker = new SegmentStatsTracker();
+    //[Fact]
+    //public async Task OnPayloadAdded_DoesNotImmediatelyReflectInStats()
+    //{
+    //    var tracker = new SegmentStatsTracker();
 
-        var storage = new InMemoryStorage();
-        var slab = await storage.CreateSlabAsync();
-        var segment = new Segment(1, 1, slab);
-        var payload = new KeyValuePair<byte[], SlabSubrange>("foo"u8.ToArray(), new SlabSubrange(10, 23));
+    //    var storage = new InMemoryStorage();
+    //    var slab = await storage.CreateSlabAsync();
+    //    var segment = new Segment(1, 1, slab);
+    //    var payload = new KeyValuePair<byte[], SlabSubrange>("foo"u8.ToArray(), new SlabSubrange(10, 23));
 
-        tracker.OnPayloadAdded(segment, payload);
+    //    tracker.OnPayloadAdded(segment, payload);
 
-        var statsBySegment = tracker.ToImmutable();
+    //    var statsBySegment = tracker.ToImmutable();
 
-        Assert.Empty(statsBySegment);
-    }
+    //    Assert.Empty(statsBySegment);
+    //}
 
-    [Fact]
-    public async Task OnPayloadAdded_SwitchingToNewOutputSegment_PreviousOutputSegmentReflectsInStats()
-    {
-        var tracker = new SegmentStatsTracker();
+    //[Fact]
+    //public async Task OnPayloadAdded_SwitchingToNewOutputSegment_PreviousOutputSegmentReflectsInStats()
+    //{
+    //    var tracker = new SegmentStatsTracker();
 
-        var storage = new InMemoryStorage();
-        var slab = await storage.CreateSlabAsync();
-        var segment1 = new Segment(1, 1, slab);
-        var payload1 = new KeyValuePair<byte[], SlabSubrange>("foo"u8.ToArray(), new SlabSubrange(10, 23));
-        var segment2 = new Segment(2, 2, slab);
-        var payload2 = new KeyValuePair<byte[], SlabSubrange>("bar"u8.ToArray(), new SlabSubrange(10, 42));
+    //    var storage = new InMemoryStorage();
+    //    var slab = await storage.CreateSlabAsync();
+    //    var segment1 = new Segment(1, 1, slab);
+    //    var payload1 = new KeyValuePair<byte[], SlabSubrange>("foo"u8.ToArray(), new SlabSubrange(10, 23));
+    //    var segment2 = new Segment(2, 2, slab);
+    //    var payload2 = new KeyValuePair<byte[], SlabSubrange>("bar"u8.ToArray(), new SlabSubrange(10, 42));
 
-        tracker.OnPayloadAdded(segment1, payload1);
-        tracker.OnPayloadAdded(segment2, payload2);
+    //    tracker.OnPayloadAdded(segment1, payload1);
+    //    tracker.OnPayloadAdded(segment2, payload2);
 
-        var statsBySegment = tracker.ToImmutable();
+    //    var statsBySegment = tracker.ToImmutable();
 
-        // There should now be a single entry in the tracker for the previous output segment
-        var singleSegmentStats = Assert.Single(statsBySegment);
-        Assert.Equal(segment1, singleSegmentStats.Key);
+    //    // There should now be a single entry in the tracker for the previous output segment
+    //    var singleSegmentStats = Assert.Single(statsBySegment);
+    //    Assert.Equal(segment1, singleSegmentStats.Key);
 
-        // The entire combined size of key + value for the payload should count against live bytes
-        Assert.Equal(0, singleSegmentStats.Value.StaleBytes);
-        Assert.Equal(3 + 23, singleSegmentStats.Value.LiveBytes);
-        Assert.Equal(3 + 23, singleSegmentStats.Value.TotalBytes);
-    }
+    //    // The entire combined size of key + value for the payload should count against live bytes
+    //    Assert.Equal(0, singleSegmentStats.Value.StaleBytes);
+    //    Assert.Equal(3 + 23, singleSegmentStats.Value.LiveBytes);
+    //    Assert.Equal(3 + 23, singleSegmentStats.Value.TotalBytes);
+    //}
 }

--- a/tests/Fugu.Core.Tests/SegmentStatsTrackerTests.cs
+++ b/tests/Fugu.Core.Tests/SegmentStatsTrackerTests.cs
@@ -5,47 +5,27 @@ namespace Fugu.Core.Tests;
 
 public class SegmentStatsTrackerTests
 {
-    //[Fact]
-    //public async Task OnPayloadAdded_DoesNotImmediatelyReflectInStats()
-    //{
-    //    var tracker = new SegmentStatsTracker();
+    [Fact]
+    public async Task Add_SegmentWithSinglePayload_ReflectsPayloadInStats()
+    {
+        // Arrange tracker and some moving bits we need to make it track a (fictional) payload
+        var tracker = new SegmentStatsTracker();
 
-    //    var storage = new InMemoryStorage();
-    //    var slab = await storage.CreateSlabAsync();
-    //    var segment = new Segment(1, 1, slab);
-    //    var payload = new KeyValuePair<byte[], SlabSubrange>("foo"u8.ToArray(), new SlabSubrange(10, 23));
+        var storage = new InMemoryStorage();
+        var slab = await storage.CreateSlabAsync();
+        var segment = new Segment(1, 1, slab);
+        var builder = new SegmentStatsBuilder(segment);
 
-    //    tracker.OnPayloadAdded(segment, payload);
+        var payload = new KeyValuePair<byte[], SlabSubrange>("foo"u8.ToArray(), new SlabSubrange(10, 23));
+        builder.OnPayloadAdded(payload);
 
-    //    var statsBySegment = tracker.ToImmutable();
+        tracker.Add(builder);
 
-    //    Assert.Empty(statsBySegment);
-    //}
+        var stats = tracker.ToImmutable();
+        var singleStatsItem = Assert.Single(stats);
 
-    //[Fact]
-    //public async Task OnPayloadAdded_SwitchingToNewOutputSegment_PreviousOutputSegmentReflectsInStats()
-    //{
-    //    var tracker = new SegmentStatsTracker();
-
-    //    var storage = new InMemoryStorage();
-    //    var slab = await storage.CreateSlabAsync();
-    //    var segment1 = new Segment(1, 1, slab);
-    //    var payload1 = new KeyValuePair<byte[], SlabSubrange>("foo"u8.ToArray(), new SlabSubrange(10, 23));
-    //    var segment2 = new Segment(2, 2, slab);
-    //    var payload2 = new KeyValuePair<byte[], SlabSubrange>("bar"u8.ToArray(), new SlabSubrange(10, 42));
-
-    //    tracker.OnPayloadAdded(segment1, payload1);
-    //    tracker.OnPayloadAdded(segment2, payload2);
-
-    //    var statsBySegment = tracker.ToImmutable();
-
-    //    // There should now be a single entry in the tracker for the previous output segment
-    //    var singleSegmentStats = Assert.Single(statsBySegment);
-    //    Assert.Equal(segment1, singleSegmentStats.Key);
-
-    //    // The entire combined size of key + value for the payload should count against live bytes
-    //    Assert.Equal(0, singleSegmentStats.Value.StaleBytes);
-    //    Assert.Equal(3 + 23, singleSegmentStats.Value.LiveBytes);
-    //    Assert.Equal(3 + 23, singleSegmentStats.Value.TotalBytes);
-    //}
+        Assert.Same(segment, singleStatsItem.Key);
+        Assert.Equal(payload.Key.Length + payload.Value.Length, singleStatsItem.Value.LiveBytes);
+        Assert.Equal(0, singleStatsItem.Value.StaleBytes);
+    }
 }


### PR DESCRIPTION
Contributes a first implementation of compaction mechanics that works by:

1. Detecting that balance invariants derived from geometric series properties are violated,
2. Identifying a small sub-range of segments that are cheapest to compact,
3. Merging these segments into a new output segment,
4. Reflecting these changes in store state.

Tasks:

- [X] Track stats and detect imbalances
- [X] Write compacted segment
- [X] Queue source segments for eviction
- [x] Update index from compaction results
- [x] Evict source segments once they can no longer be referenced through snapshots