### PR TITLE
Narrow down usage of channel reader/writer types by actors

### DIFF
--- a/src/Fugu.Core/Actors/AllocationActor.cs
+++ b/src/Fugu.Core/Actors/AllocationActor.cs
@@ -26,13 +26,13 @@ public sealed class AllocationActor
 
     public AllocationActor(
         IBackingStorage storage,
-        Channel<SegmentsCompacted> segmentsCompactedChannel,
-        Channel<ChangeSetAllocated> changeSetAllocatedChannel,
+        ChannelReader<SegmentsCompacted> segmentsCompactedChannelReader,
+        ChannelWriter<ChangeSetAllocated> changeSetAllocatedChannelWriter,
         long totalBytes)
     {
         _storage = storage;
-        _segmentsCompactedChannelReader = segmentsCompactedChannel.Reader;
-        _changeSetAllocatedChannelWriter = changeSetAllocatedChannel.Writer;
+        _segmentsCompactedChannelReader = segmentsCompactedChannelReader;
+        _changeSetAllocatedChannelWriter = changeSetAllocatedChannelWriter;
         _totalBytes = totalBytes;
     }
 

--- a/src/Fugu.Core/Actors/CompactionActor.cs
+++ b/src/Fugu.Core/Actors/CompactionActor.cs
@@ -10,10 +10,10 @@ public sealed class CompactionActor
     private readonly SemaphoreSlim _semaphore = new(1);
 
     private readonly IBackingStorage _storage;
-    private readonly Channel<SegmentStatsUpdated> _segmentStatsUpdatedChannel;
-    private readonly Channel<OldestObservableSnapshotChanged> _oldestObservableSnapshotChangedChannel;
-    private readonly Channel<CompactionWritten> _compactionWrittenChannel;
-    private readonly Channel<SegmentsCompacted> _segmentsCompactedChannel;
+    private readonly ChannelReader<SegmentStatsUpdated> _segmentStatsUpdatedChannelReader;
+    private readonly ChannelReader<OldestObservableSnapshotChanged> _oldestObservableSnapshotChangedChannelReader;
+    private readonly ChannelWriter<CompactionWritten> _compactionWrittenChannelWriter;
+    private readonly ChannelWriter<SegmentsCompacted> _segmentsCompactedChannelWriter;
 
     private readonly PriorityQueue<Segment, VectorClock> _segmentsAwaitingRemoval = new(
         Comparer<VectorClock>.Create((x, y) =>
@@ -34,10 +34,10 @@ public sealed class CompactionActor
         Channel<SegmentsCompacted> segmentsCompactedChannel)
     {
         _storage = storage;
-        _segmentStatsUpdatedChannel = segmentStatsUpdatedChannel;
-        _oldestObservableSnapshotChangedChannel = oldestObservableSnapshotChangedChannel;
-        _compactionWrittenChannel = compactionWrittenChannel;
-        _segmentsCompactedChannel = segmentsCompactedChannel;
+        _segmentStatsUpdatedChannelReader = segmentStatsUpdatedChannel.Reader;
+        _oldestObservableSnapshotChangedChannelReader = oldestObservableSnapshotChangedChannel.Reader;
+        _compactionWrittenChannelWriter = compactionWrittenChannel.Writer;
+        _segmentsCompactedChannelWriter = segmentsCompactedChannel.Writer;
     }
 
     public async Task RunAsync()
@@ -46,16 +46,16 @@ public sealed class CompactionActor
             ProcessSegmentStatsUpdatedMessagesAsync(),
             ProcessOldestObservableSnapshotChangedMessagesAsync());
 
-        _segmentsCompactedChannel.Writer.Complete();
+        _segmentsCompactedChannelWriter.Complete();
     }
 
     private async Task ProcessSegmentStatsUpdatedMessagesAsync()
     {
         long compactionClockThreshold = 0;
 
-        while (await _segmentStatsUpdatedChannel.Reader.WaitToReadAsync())
+        while (await _segmentStatsUpdatedChannelReader.WaitToReadAsync())
         {
-            var message = await _segmentStatsUpdatedChannel.Reader.ReadAsync();
+            var message = await _segmentStatsUpdatedChannelReader.ReadAsync();
 
             // Discard messages while we're still waiting for the effects of a previous compaction to become observable
             if (message.Clock.Compaction < compactionClockThreshold)
@@ -112,7 +112,7 @@ public sealed class CompactionActor
                         sourceStats.Select(kvp => kvp.Key).ToArray(),
                         message.Index);
 
-                    await _compactionWrittenChannel.Writer.WriteAsync(
+                    await _compactionWrittenChannelWriter.WriteAsync(
                         new CompactionWritten(
                             Clock: message.Clock with { Compaction = compactionClockThreshold },
                             OutputSegment: compactedSegment,
@@ -134,7 +134,7 @@ public sealed class CompactionActor
                     // account for it by making future segments smaller again.
                     // Note that we can either do this here, OR when the old segments actually get evicted because
                     // no snapshots reference them anymore.
-                    await _segmentsCompactedChannel.Writer.WriteAsync(
+                    await _segmentsCompactedChannelWriter.WriteAsync(
                         new SegmentsCompacted(CapacityChange: capacityChange));
                 }
             }
@@ -145,14 +145,14 @@ public sealed class CompactionActor
         }
 
         // Propagate completion
-        _compactionWrittenChannel.Writer.Complete();
+        _compactionWrittenChannelWriter.Complete();
     }
 
     private async Task ProcessOldestObservableSnapshotChangedMessagesAsync()
     {
-        while (await _oldestObservableSnapshotChangedChannel.Reader.WaitToReadAsync())
+        while (await _oldestObservableSnapshotChangedChannelReader.WaitToReadAsync())
         {
-            var message = await _oldestObservableSnapshotChangedChannel.Reader.ReadAsync();
+            var message = await _oldestObservableSnapshotChangedChannelReader.ReadAsync();
             await _semaphore.WaitAsync();
 
             try

--- a/src/Fugu.Core/Actors/CompactionActor.cs
+++ b/src/Fugu.Core/Actors/CompactionActor.cs
@@ -28,16 +28,16 @@ public sealed class CompactionActor
 
     public CompactionActor(
         IBackingStorage storage,
-        Channel<SegmentStatsUpdated> segmentStatsUpdatedChannel,
-        Channel<OldestObservableSnapshotChanged> oldestObservableSnapshotChangedChannel,
-        Channel<CompactionWritten> compactionWrittenChannel,
-        Channel<SegmentsCompacted> segmentsCompactedChannel)
+        ChannelReader<SegmentStatsUpdated> segmentStatsUpdatedChannelReader,
+        ChannelReader<OldestObservableSnapshotChanged> oldestObservableSnapshotChangedChannelReader,
+        ChannelWriter<CompactionWritten> compactionWrittenChannelWriter,
+        ChannelWriter<SegmentsCompacted> segmentsCompactedChannelWriter)
     {
         _storage = storage;
-        _segmentStatsUpdatedChannelReader = segmentStatsUpdatedChannel.Reader;
-        _oldestObservableSnapshotChangedChannelReader = oldestObservableSnapshotChangedChannel.Reader;
-        _compactionWrittenChannelWriter = compactionWrittenChannel.Writer;
-        _segmentsCompactedChannelWriter = segmentsCompactedChannel.Writer;
+        _segmentStatsUpdatedChannelReader = segmentStatsUpdatedChannelReader;
+        _oldestObservableSnapshotChangedChannelReader = oldestObservableSnapshotChangedChannelReader;
+        _compactionWrittenChannelWriter = compactionWrittenChannelWriter;
+        _segmentsCompactedChannelWriter = segmentsCompactedChannelWriter;
     }
 
     public async Task RunAsync()

--- a/src/Fugu.Core/Actors/IndexActor.cs
+++ b/src/Fugu.Core/Actors/IndexActor.cs
@@ -19,15 +19,15 @@ public sealed partial class IndexActor
     private readonly SegmentStatsTracker _statsTracker = new();
 
     public IndexActor(
-        Channel<ChangesWritten> changesWrittenChannel,
-        Channel<CompactionWritten> compactionWrittenChannel,
-        Channel<IndexUpdated> indexUpdatedChannel,
-        Channel<SegmentStatsUpdated> segmentStatsUpdatedChannel)
+        ChannelReader<ChangesWritten> changesWrittenChannelReader,
+        ChannelReader<CompactionWritten> compactionWrittenChannelReader,
+        ChannelWriter<IndexUpdated> indexUpdatedChannelWriter,
+        ChannelWriter<SegmentStatsUpdated> segmentStatsUpdatedChannelWriter)
     {
-        _changesWrittenChannelReader = changesWrittenChannel.Reader;
-        _compactionWrittenChannelReader = compactionWrittenChannel.Reader;
-        _indexUpdatedChannelWriter = indexUpdatedChannel.Writer;
-        _segmentStatsUpdatedChannelWriter = segmentStatsUpdatedChannel.Writer;
+        _changesWrittenChannelReader = changesWrittenChannelReader;
+        _compactionWrittenChannelReader = compactionWrittenChannelReader;
+        _indexUpdatedChannelWriter = indexUpdatedChannelWriter;
+        _segmentStatsUpdatedChannelWriter = segmentStatsUpdatedChannelWriter;
     }
 
     public async Task RunAsync()

--- a/src/Fugu.Core/Actors/IndexActor.cs
+++ b/src/Fugu.Core/Actors/IndexActor.cs
@@ -9,10 +9,10 @@ public sealed partial class IndexActor
 {
     private readonly SemaphoreSlim _semaphore = new(1);
 
-    private readonly Channel<ChangesWritten> _changesWrittenChannel;
-    private readonly Channel<CompactionWritten> _compactionWrittenChannel;
-    private readonly Channel<IndexUpdated> _indexUpdatedChannel;
-    private readonly Channel<SegmentStatsUpdated> _segmentStatsUpdatedChannel;
+    private readonly ChannelReader<ChangesWritten> _changesWrittenChannelReader;
+    private readonly ChannelReader<CompactionWritten> _compactionWrittenChannelReader;
+    private readonly ChannelWriter<IndexUpdated> _indexUpdatedChannelWriter;
+    private readonly ChannelWriter<SegmentStatsUpdated> _segmentStatsUpdatedChannelWriter;
 
     private VectorClock _clock = default;
     private ImmutableDictionary<byte[], IndexEntry> _index = ImmutableDictionary.Create<byte[], IndexEntry>(ByteArrayEqualityComparer.Shared);
@@ -24,10 +24,10 @@ public sealed partial class IndexActor
         Channel<IndexUpdated> indexUpdatedChannel,
         Channel<SegmentStatsUpdated> segmentStatsUpdatedChannel)
     {
-        _changesWrittenChannel = changesWrittenChannel;
-        _compactionWrittenChannel = compactionWrittenChannel;
-        _indexUpdatedChannel = indexUpdatedChannel;
-        _segmentStatsUpdatedChannel = segmentStatsUpdatedChannel;
+        _changesWrittenChannelReader = changesWrittenChannel.Reader;
+        _compactionWrittenChannelReader = compactionWrittenChannel.Reader;
+        _indexUpdatedChannelWriter = indexUpdatedChannel.Writer;
+        _segmentStatsUpdatedChannelWriter = segmentStatsUpdatedChannel.Writer;
     }
 
     public async Task RunAsync()
@@ -41,9 +41,9 @@ public sealed partial class IndexActor
     {
         SegmentStatsBuilder? currentOutputSegmentStatsBuilder = null;
 
-        while (await _changesWrittenChannel.Reader.WaitToReadAsync())
+        while (await _changesWrittenChannelReader.WaitToReadAsync())
         {
-            var message = await _changesWrittenChannel.Reader.ReadAsync();
+            var message = await _changesWrittenChannelReader.ReadAsync();
             await _semaphore.WaitAsync();
 
             try
@@ -113,14 +113,14 @@ public sealed partial class IndexActor
                 var stats = _statsTracker.ToImmutable();
                 EnsureIndexAndStatsConsistent(_index, stats);
 
-                await _indexUpdatedChannel.Writer.WriteAsync(
+                await _indexUpdatedChannelWriter.WriteAsync(
                     new IndexUpdated(
                         Clock: _clock,
                         Index: _index));
 
                 if (!stats.IsEmpty)
                 {
-                    await _segmentStatsUpdatedChannel.Writer.WriteAsync(
+                    await _segmentStatsUpdatedChannelWriter.WriteAsync(
                         new SegmentStatsUpdated(
                             Clock: _clock,
                             Stats: stats,
@@ -134,15 +134,15 @@ public sealed partial class IndexActor
         }
 
         // Propagate completion
-        _indexUpdatedChannel.Writer.Complete();
-        _segmentStatsUpdatedChannel.Writer.Complete();
+        _indexUpdatedChannelWriter.Complete();
+        _segmentStatsUpdatedChannelWriter.Complete();
     }
 
     private async Task ProcessCompactionWrittenMessagesAsync()
     {
-        while (await _compactionWrittenChannel.Reader.WaitToReadAsync())
+        while (await _compactionWrittenChannelReader.WaitToReadAsync())
         {
-            var message = await _compactionWrittenChannel.Reader.ReadAsync();
+            var message = await _compactionWrittenChannelReader.ReadAsync();
             await _semaphore.WaitAsync();
 
             try
@@ -188,7 +188,7 @@ public sealed partial class IndexActor
                 var stats = _statsTracker.ToImmutable();
                 EnsureIndexAndStatsConsistent(_index, stats);
 
-                await _indexUpdatedChannel.Writer.WriteAsync(
+                await _indexUpdatedChannelWriter.WriteAsync(
                     new IndexUpdated(
                         Clock: _clock,
                         Index: _index));
@@ -196,7 +196,7 @@ public sealed partial class IndexActor
 
                 if (!stats.IsEmpty)
                 {
-                    await _segmentStatsUpdatedChannel.Writer.WriteAsync(
+                    await _segmentStatsUpdatedChannelWriter.WriteAsync(
                         new SegmentStatsUpdated(
                             Clock: _clock,
                             Stats: stats,

--- a/src/Fugu.Core/Actors/SnapshotsActor.cs
+++ b/src/Fugu.Core/Actors/SnapshotsActor.cs
@@ -36,11 +36,11 @@ public sealed class SnapshotsActor : ISnapshotOwner
         }));
 
     public SnapshotsActor(
-        Channel<IndexUpdated> indexUpdatedChannel,
-        Channel<OldestObservableSnapshotChanged> oldestObservableSnapshotChangedChannel)
+        ChannelReader<IndexUpdated> indexUpdatedChannelReader,
+        ChannelWriter<OldestObservableSnapshotChanged> oldestObservableSnapshotChangedChannelWriter)
     {
-        _indexUpdatedChannelReader = indexUpdatedChannel.Reader;
-        _oldestObservableSnapshotChangedChannelWriter = oldestObservableSnapshotChangedChannel.Writer;
+        _indexUpdatedChannelReader = indexUpdatedChannelReader;
+        _oldestObservableSnapshotChangedChannelWriter = oldestObservableSnapshotChangedChannelWriter;
     }
 
     public async Task RunAsync()

--- a/src/Fugu.Core/Actors/SnapshotsActor.cs
+++ b/src/Fugu.Core/Actors/SnapshotsActor.cs
@@ -7,8 +7,8 @@ namespace Fugu.Actors;
 public sealed class SnapshotsActor : ISnapshotOwner
 {
     private readonly SemaphoreSlim _semaphore = new(1);
-    private readonly Channel<IndexUpdated> _indexUpdatedChannel;
-    private readonly Channel<OldestObservableSnapshotChanged> _oldestObservableSnapshotChangedChannel;
+    private readonly ChannelReader<IndexUpdated> _indexUpdatedChannelReader;
+    private readonly ChannelWriter<OldestObservableSnapshotChanged> _oldestObservableSnapshotChangedChannelWriter;
 
     private VectorClock _clock;
     private IReadOnlyDictionary<byte[], IndexEntry> _index = new Dictionary<byte[], IndexEntry>();
@@ -39,15 +39,15 @@ public sealed class SnapshotsActor : ISnapshotOwner
         Channel<IndexUpdated> indexUpdatedChannel,
         Channel<OldestObservableSnapshotChanged> oldestObservableSnapshotChangedChannel)
     {
-        _indexUpdatedChannel = indexUpdatedChannel;
-        _oldestObservableSnapshotChangedChannel = oldestObservableSnapshotChangedChannel;
+        _indexUpdatedChannelReader = indexUpdatedChannel.Reader;
+        _oldestObservableSnapshotChangedChannelWriter = oldestObservableSnapshotChangedChannel.Writer;
     }
 
     public async Task RunAsync()
     {
-        while (await _indexUpdatedChannel.Reader.WaitToReadAsync())
+        while (await _indexUpdatedChannelReader.WaitToReadAsync())
         {
-            var message = await _indexUpdatedChannel.Reader.ReadAsync();
+            var message = await _indexUpdatedChannelReader.ReadAsync();
             await _semaphore.WaitAsync();
 
             try
@@ -78,7 +78,7 @@ public sealed class SnapshotsActor : ISnapshotOwner
                 // observed anymore.
                 if (compactionClockStepped && _activeSnapshotsByClock.Count == 0)
                 {
-                    await _oldestObservableSnapshotChangedChannel.Writer.WriteAsync(
+                    await _oldestObservableSnapshotChangedChannelWriter.WriteAsync(
                         new OldestObservableSnapshotChanged(_clock));
                 }
             }
@@ -91,7 +91,7 @@ public sealed class SnapshotsActor : ISnapshotOwner
         // TODO: Maybe wait until all open snapshots have been disposed?
         // Or throw if there are any open snapshots around?
 
-        _oldestObservableSnapshotChangedChannel.Writer.Complete();
+        _oldestObservableSnapshotChangedChannelWriter.Complete();
     }
 
     public async ValueTask WaitForObservableEffectsAsync(VectorClock threshold)
@@ -155,7 +155,7 @@ public sealed class SnapshotsActor : ISnapshotOwner
                 var oldestClock = _activeSnapshotsByClock.Keys.DefaultIfEmpty(_clock).First();
                 if (oldestClock >= snapshot.Clock)
                 {
-                    await _oldestObservableSnapshotChangedChannel.Writer.WriteAsync(
+                    await _oldestObservableSnapshotChangedChannelWriter.WriteAsync(
                         new OldestObservableSnapshotChanged(oldestClock)
                     );
                 }

--- a/src/Fugu.Core/Actors/WriterActor.cs
+++ b/src/Fugu.Core/Actors/WriterActor.cs
@@ -13,12 +13,12 @@ public sealed class WriterActor
     private SegmentBuilder? _segmentBuilder;
 
     public WriterActor(
-        Channel<ChangeSetAllocated> changeSetAllocatedChannel,
-        Channel<ChangesWritten> changesWrittenChannel,
+        ChannelReader<ChangeSetAllocated> changeSetAllocatedChannelReader,
+        ChannelWriter<ChangesWritten> changesWrittenChannelWriter,
         long maxGeneration)
     {
-        _changeSetAllocatedChannelReader = changeSetAllocatedChannel.Reader;
-        _changesWrittenChannelWriter = changesWrittenChannel.Writer;
+        _changeSetAllocatedChannelReader = changeSetAllocatedChannelReader;
+        _changesWrittenChannelWriter = changesWrittenChannelWriter;
         _outputGeneration = maxGeneration;
     }
 

--- a/src/Fugu.Core/Actors/WriterActor.cs
+++ b/src/Fugu.Core/Actors/WriterActor.cs
@@ -6,8 +6,8 @@ namespace Fugu.Actors;
 
 public sealed class WriterActor
 {
-    private readonly Channel<ChangeSetAllocated> _changeSetAllocatedChannel;
-    private readonly Channel<ChangesWritten> _changesWrittenChannel;
+    private readonly ChannelReader<ChangeSetAllocated> _changeSetAllocatedChannelReader;
+    private readonly ChannelWriter<ChangesWritten> _changesWrittenChannelWriter;
 
     private long _outputGeneration;
     private SegmentBuilder? _segmentBuilder;
@@ -17,16 +17,16 @@ public sealed class WriterActor
         Channel<ChangesWritten> changesWrittenChannel,
         long maxGeneration)
     {
-        _changeSetAllocatedChannel = changeSetAllocatedChannel;
-        _changesWrittenChannel = changesWrittenChannel;
+        _changeSetAllocatedChannelReader = changeSetAllocatedChannel.Reader;
+        _changesWrittenChannelWriter = changesWrittenChannel.Writer;
         _outputGeneration = maxGeneration;
     }
 
     public async Task RunAsync()
     {
-        while (await _changeSetAllocatedChannel.Reader.WaitToReadAsync())
+        while (await _changeSetAllocatedChannelReader.WaitToReadAsync())
         {
-            var message = await _changeSetAllocatedChannel.Reader.ReadAsync();
+            var message = await _changeSetAllocatedChannelReader.ReadAsync();
 
             if (_segmentBuilder is null || message.OutputSlab != _segmentBuilder.Segment.Slab)
             {
@@ -46,7 +46,7 @@ public sealed class WriterActor
             var writtenPayloads = await _segmentBuilder.WriteChangeSetAsync(message.ChangeSet);
 
             // Propagate changes downstream
-            await _changesWrittenChannel.Writer.WriteAsync(
+            await _changesWrittenChannelWriter.WriteAsync(
                 new ChangesWritten(
                     Clock: message.Clock,
                     OutputSegment: _segmentBuilder.Segment,
@@ -57,6 +57,6 @@ public sealed class WriterActor
         // TODO: Terminate current output segment, if any
 
         // Propagate completion
-        _changesWrittenChannel.Writer.Complete();
+        _changesWrittenChannelWriter.Complete();
     }
 }


### PR DESCRIPTION
Until now, actors received a reference to the underlying `Channel<T>` object for every connection they participated in. However, each actor will either only read from or write to a channel.

Hence, this PR improves encapsulation by making actors refer specifically to either the reader or writer of each associated channel, but never both.