### PR TITLE
Tear down actor mesh by shutting down CompactionActor via CancellationToken

### DIFF
--- a/src/Fugu.Core/Actors/AllocationActor.cs
+++ b/src/Fugu.Core/Actors/AllocationActor.cs
@@ -57,20 +57,9 @@ public sealed class AllocationActor
                 _semaphore.Release();
             }
         }
-    }
 
-    public async Task CompleteAsync()
-    {
-        await _semaphore.WaitAsync();
-
-        try
-        {
-            _changeSetAllocatedChannelWriter.Complete();
-        }
-        finally
-        {
-            _semaphore.Release();
-        }
+        // Propagate completion
+        _changeSetAllocatedChannelWriter.Complete();
     }
 
     public async ValueTask<VectorClock> EnqueueChangeSetAsync(ChangeSet changeSet)
@@ -97,7 +86,7 @@ public sealed class AllocationActor
             {
                 _outputSlab = await _storage.CreateSlabAsync();
                 _outputSlabSizeLimit = GetOutputSizeLimit(_totalBytes);
-             }
+            }
 
             _outputSlabBytesWritten += ChangeSetUtils.GetDataBytes(changeSet);
 

--- a/src/Fugu.Core/Actors/IndexActor.cs
+++ b/src/Fugu.Core/Actors/IndexActor.cs
@@ -35,6 +35,10 @@ public sealed partial class IndexActor
         await Task.WhenAll(
             ProcessChangesWrittenMessagesAsync(),
             ProcessCompactionWrittenMessagesAsync());
+
+        // Propagate completion
+        _indexUpdatedChannelWriter.Complete();
+        _segmentStatsUpdatedChannelWriter.Complete();
     }
 
     private async Task ProcessChangesWrittenMessagesAsync()
@@ -132,10 +136,6 @@ public sealed partial class IndexActor
                 _semaphore.Release();
             }
         }
-
-        // Propagate completion
-        _indexUpdatedChannelWriter.Complete();
-        _segmentStatsUpdatedChannelWriter.Complete();
     }
 
     private async Task ProcessCompactionWrittenMessagesAsync()


### PR DESCRIPTION
When shutting down a `KeyValueStore` instance, the process is based on the intuition of completing a few channels that connect actors, then letting completion propagate from actor to actor until all actors have been stopped.

So far, teardown began in `AllocationActor` and propagated through `WriterActor` and `IndexActor`. With `IndexActor` now accepting both `ChangesWritten` and `CompactionWritten` messages, this approach became unreliable if a compaction attempted to merge into the main index while the write path was already shut down, thus severing the outgoing channels to update snapshots. At the same time, propagating completion towards `CompactionActor` from `IndexActor` turned out to be difficult due to the circular dependency between these two actors.

Hence, this PR revises the teardown approach in such a way that:

- Teardown now begins at `CompactionActor`, breaking out of both processing loops with the help of an initial `CancellationToken`.
- Outbound channels from `CompactionActor` are then completed. Completion ripples through the actor mesh as before.
- `IndexActor` sees the closure of both its `ChangesWritten` and its `CompactionWritten` input channels, but only completes its outgoing channels until *both* input channels have been drained.

Overall, this approach tackles the tricky circular dependency between `IndexActor` and `CompactionActor` right at the start, allowing us to defer to the original logic of letting completion ripple through channels toward consumers virtually unaltered.