### PR TITLE
Defer compaction cleanup until no snapshots can see old state

### DIFF
--- a/src/Fugu.Core/Utils/PendingCompactionCleanup.cs
+++ b/src/Fugu.Core/Utils/PendingCompactionCleanup.cs
@@ -1,0 +1,13 @@
+﻿namespace Fugu.Utils;
+
+/// <summary>
+/// Remaining cleanup activities to be performed after a compaction.
+/// </summary>
+/// <param name="CompactionClock">The compaction clock component after which the cleanup can be performed.</param>
+/// <param name="Segments">The source segments for the compaction, to be removed from the store.</param>
+/// <param name="CapacityChange">The net change in total store capacity that resulted from the compaction.</param>
+internal record PendingCompactionCleanup(
+    long CompactionClock,
+    Segment[] Segments,
+    long CapacityChange
+);


### PR DESCRIPTION
When a compaction completes, the resulting changes are merged back into the index. However, the old segments need to be kept around for a while because open snapshots might still reference old versions of the index that point to the old segments. The compaction actor can only delete these segments when all open snapshots can see a state that's at least as new as the compacted state.

This PR improves the existing post-compaction cleanup as follows:

* Introduce a new `PendingCompactionCleanup` type that holds source segments, net capacity change, etc.
* Communicate overall capacity change to `AllocationActor` only after source segments have been removed. This is to avoid scenarios in which many segment files could remain open due to constant churn under sustained writes.
* Replace priority queue with simple FIFO queue to store pending cleanup activities, as the cleanup order is guaranteed to be the same as compaction order.