### PR TITLE
Fix: offset updates didn't account for new checksum field

### DIFF
--- a/src/Fugu.Core/IO/SegmentWriter.cs
+++ b/src/Fugu.Core/IO/SegmentWriter.cs
@@ -67,7 +67,7 @@ public sealed class SegmentWriter
         var payloads = changeSet.Payloads.ToArray();
         var tombstones = changeSet.Tombstones.ToArray();
 
-        var headerLength = Unsafe.SizeOf<int>() * (2 + 2 * changeSet.Payloads.Count + changeSet.Tombstones.Count);
+        var headerLength = Unsafe.SizeOf<int>() * (2 + (2 * changeSet.Payloads.Count) + changeSet.Tombstones.Count);
 
         // The following code relies on PipeWriter implementing IBufferWriter<byte>
         {
@@ -122,7 +122,9 @@ public sealed class SegmentWriter
         var checksum = _hash64.GetCurrentHashAsUInt64();
         Span<byte> checksumBytes = stackalloc byte[sizeof(ulong)];
         BinaryPrimitives.WriteUInt64LittleEndian(checksumBytes, checksum);
+
         _pipeWriter.Write(checksumBytes);
+        _offset += checksumBytes.Length;
 
         return new ChangeSetCoordinates(writtenPayloads, tombstones);
     }

--- a/tests/Fugu.Core.Tests/KeyValueStoreTests.cs
+++ b/tests/Fugu.Core.Tests/KeyValueStoreTests.cs
@@ -13,17 +13,22 @@ public class KeyValueStoreTests
         var storage = new InMemoryStorage();
         await using var store = await KeyValueStore.CreateAsync(storage);
 
-        var changeSet = new ChangeSet
+        await store.SaveAsync(new ChangeSet
         {
             ["foo"u8] = Encoding.UTF8.GetBytes("Hello, world"),
-        };
+        });
 
-        await store.SaveAsync(changeSet);
+        await store.SaveAsync(new ChangeSet
+        {
+            ["bar"u8] = Encoding.UTF8.GetBytes("Still works"),
+        });
 
         using var snapshot = await store.GetSnapshotAsync();
-        var retrievedValue = await snapshot.ReadAsync("foo"u8);
+        var retrievedFooValue = await snapshot.ReadAsync("foo"u8);
+        var retrievedBarValue = await snapshot.ReadAsync("bar"u8);
 
-        Assert.Equal("Hello, world", Encoding.UTF8.GetString(retrievedValue.ToArray()));
+        Assert.Equal("Hello, world", Encoding.UTF8.GetString(retrievedFooValue.ToArray()));
+        Assert.Equal("Still works", Encoding.UTF8.GetString(retrievedBarValue.ToArray()));
     }
 
     [Fact]


### PR DESCRIPTION
Introducing the new trailing checksum field in #27 failed to adapt the offset updates in `SegmentWriter` accordingly. As a result, recorded payload value positions were wrong, pointing to earlier positions in the slab than they should have.

This PR adapts `SegmentWriter` to update the `_offset` field correctly again. Extended the basic read/write test to cover this kind of corruption, since it only affected change sets after the initial one.