### PR TITLE
Resolve bootstrap order, discard unused segments during startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,6 @@ Data within each segment is stored in a format that is designed to be reasonably
   Payload value lengths   : uint32[]
   Payload keys            : byte[]
   Tombstone keys          : byte[]
-  Paylaod values          : byte[]
+  Payload values          : byte[]
   Running checksum        : uint64
 ```

--- a/src/Fugu.Core/ISegmentMetadata.cs
+++ b/src/Fugu.Core/ISegmentMetadata.cs
@@ -1,0 +1,7 @@
+﻿namespace Fugu;
+
+public interface ISegmentMetadata
+{
+    long MaxGeneration { get; }
+    long MinGeneration { get; }
+}

--- a/src/Fugu.Core/Segment.cs
+++ b/src/Fugu.Core/Segment.cs
@@ -2,10 +2,15 @@
 
 namespace Fugu;
 
-public sealed class Segment
+public sealed class Segment : ISegmentMetadata
 {
     public Segment(long minGeneration, long maxGeneration, ISlab slab)
     {
+        if (minGeneration > maxGeneration)
+        {
+            throw new ArgumentException("Min generation cannot exceed max generation.");
+        }
+
         MinGeneration = minGeneration;
         MaxGeneration = maxGeneration;
         Slab = slab;
@@ -14,6 +19,6 @@ public sealed class Segment
     public long MinGeneration { get; }
 
     public long MaxGeneration { get; }
-    
+
     public ISlab Slab { get; }
 }

--- a/src/Fugu.Core/Utils/BootstrapSegmentOrderer.cs
+++ b/src/Fugu.Core/Utils/BootstrapSegmentOrderer.cs
@@ -5,9 +5,25 @@ public static class BootstrapSegmentOrderer
     public static IReadOnlyList<ISegmentMetadata> GetBootstrapOrder(IEnumerable<ISegmentMetadata> segments)
     {
         var byGeneration = segments
-            .OrderBy(s => s.MinGeneration)
-            .ThenBy(s => s.MaxGeneration);
+            .OrderBy(s => s.MaxGeneration)
+            .ThenByDescending(s => s.MinGeneration);
 
-        return [.. byGeneration];
+        var stack = new Stack<ISegmentMetadata>();
+
+        foreach (var segment in byGeneration)
+        {
+            // If the current segment does not extend past the topmost segment already on the stack, discard it.
+            if (stack.TryPeek(out var top) && segment.MaxGeneration <= top.MaxGeneration)
+            {
+                continue;
+            }
+
+            stack.Push(segment);
+        }
+
+        var result = stack.ToList();
+        result.Reverse();
+
+        return result;
     }
 }

--- a/src/Fugu.Core/Utils/BootstrapSegmentOrderer.cs
+++ b/src/Fugu.Core/Utils/BootstrapSegmentOrderer.cs
@@ -2,28 +2,61 @@
 
 public static class BootstrapSegmentOrderer
 {
+    /// <summary>
+    /// Given a collection of segments available in storage, determines which of these segments to load (and in
+    /// which order) to restore the contents of the store.
+    /// </summary>
+    /// <param name="segments">Metadata for segments available in storage.</param>
+    /// <returns>An ordered list of segments to load.</returns>
+    /// <exception cref="InvalidOperationException">The algorithm encountered an invalid state.</exception>
     public static IReadOnlyList<ISegmentMetadata> GetBootstrapOrder(IEnumerable<ISegmentMetadata> segments)
     {
-        var byGeneration = segments
-            .OrderBy(s => s.MaxGeneration)
-            .ThenByDescending(s => s.MinGeneration);
+        long maxGenerationAccepted = 0;
+
+        // Order segments so that for each max generation, shorter segments (= higher min generation) are evaluated
+        // before looking at longer-range segments that extend to the same max generation. As a consequence, the
+        // algorithm will forgo longer segments arising from compactions if all of the source segments are still
+        // available. Only when it detects gaps in the sequence of smaller segments will it use a longer-range
+        // segment instead.
+        var byGeneration = new Queue<ISegmentMetadata>(
+            segments
+                .OrderBy(s => s.MaxGeneration)
+                .ThenByDescending(s => s.MinGeneration));
 
         var stack = new Stack<ISegmentMetadata>();
 
-        foreach (var segment in byGeneration)
+        while (byGeneration.TryDequeue(out var segment))
         {
             // If the current segment does not extend past the topmost segment already on the stack, discard it.
-            if (stack.TryPeek(out var top) && segment.MaxGeneration <= top.MaxGeneration)
+            if (segment.MaxGeneration <= maxGenerationAccepted)
             {
                 continue;
             }
 
+            // If there is a gap between the max accepted generation and the lower generation bound of the current segment,
+            // we expect that this will be covered by an upcoming longer-range segment.
+            if (segment.MinGeneration > maxGenerationAccepted + 1)
+            {
+                while (segment.MinGeneration > maxGenerationAccepted + 1)
+                {
+                    if (!byGeneration.TryDequeue(out segment))
+                    {
+                        throw new InvalidOperationException("Gap found, unable to close by a covering segment.");
+                    }
+                }
+            }
+
+            // This segment might overlap previous segments already on the stack, so we need to discard items from
+            // the stack to resolve overlaps.
+            while (stack.TryPeek(out var topItem) && topItem.MaxGeneration >= segment.MinGeneration)
+            {
+                stack.Pop();
+            }
+
             stack.Push(segment);
+            maxGenerationAccepted = segment.MaxGeneration;
         }
 
-        var result = stack.ToList();
-        result.Reverse();
-
-        return result;
+        return stack.Reverse().ToArray();
     }
 }

--- a/src/Fugu.Core/Utils/BootstrapSegmentOrderer.cs
+++ b/src/Fugu.Core/Utils/BootstrapSegmentOrderer.cs
@@ -1,0 +1,13 @@
+﻿namespace Fugu.Utils;
+
+public static class BootstrapSegmentOrderer
+{
+    public static IReadOnlyList<ISegmentMetadata> GetBootstrapOrder(IEnumerable<ISegmentMetadata> segments)
+    {
+        var byGeneration = segments
+            .OrderBy(s => s.MinGeneration)
+            .ThenBy(s => s.MaxGeneration);
+
+        return [.. byGeneration];
+    }
+}

--- a/tests/Fugu.Core.Tests/BootstrapSegmentOrdererTests.cs
+++ b/tests/Fugu.Core.Tests/BootstrapSegmentOrdererTests.cs
@@ -32,13 +32,66 @@ public class BootstrapSegmentOrdererTests
         ISegmentMetadata[] segments =
         [
             new TestSegmentMetadata(3, 3),
-            new TestSegmentMetadata(1, 3),          // This one should be ignored, since the other two cover the entire 1-3 range.
+            new TestSegmentMetadata(1, 3),      // This one should be ignored, since the other two cover the entire 1-3 range.
             new TestSegmentMetadata(1, 2),
         ];
 
         var result = BootstrapSegmentOrderer.GetBootstrapOrder(segments);
 
         Assert.Equal([segments[2], segments[0]], result);
+    }
+
+    [Fact]
+    public void GetBootstrapOrder_MissingGen1InSmallSegments_CoversWithLargerSegment()
+    {
+        // The following set of segments has (2, 2) and (3, 3) ranges, but does NOT have a (1, 1) range. This could have
+        // happened if the host program crashed after a compaction of (1, 1) through (3, 3) into (1, 3), at a point where
+        // (1, 1) had already been removed.
+        ISegmentMetadata[] segments =
+        [
+            new TestSegmentMetadata(2, 2),
+            new TestSegmentMetadata(3, 3),
+            new TestSegmentMetadata(4, 4),
+            new TestSegmentMetadata(1, 3),      // This one should be used instead of the (2, 2) and (3, 3) segments.
+        ];
+
+        var result = BootstrapSegmentOrderer.GetBootstrapOrder(segments);
+
+        Assert.Equal([segments[3], segments[2]], result);
+    }
+
+    [Fact]
+    public void GetBootstrapOrder_MissingLastGenInSmallSegments_CoversWithLargerSegment()
+    {
+        // The following set of segments could have occurred after compacting segments (1, 1), (2, 2) and (3, 3) into a
+        // new (1, 3) segment, but the host program crashed after the (3, 3) segment had already been removed and (1, 1)
+        // and (2, 2) had not.
+        ISegmentMetadata[] segments =
+        [
+            new TestSegmentMetadata(1, 1),
+            new TestSegmentMetadata(1, 3),      // Should use this one only.
+            new TestSegmentMetadata(2, 2),
+        ];
+
+        var result = BootstrapSegmentOrderer.GetBootstrapOrder(segments);
+
+        Assert.Equal([segments[1]], result);
+    }
+
+    [Fact]
+    public void GetBootstrapOrder_GapInSmallSegments_CoversWithLargerSegment()
+    {
+        ISegmentMetadata[] segments =
+        [
+            new TestSegmentMetadata(1, 1),
+            new TestSegmentMetadata(3, 3),
+            new TestSegmentMetadata(4, 4),
+            new TestSegmentMetadata(1, 3),      // This one should be used instead of the (1, 1) and (3, 3) segments.
+        ];
+
+        var result = BootstrapSegmentOrderer.GetBootstrapOrder(segments);
+
+        Assert.Equal([segments[3], segments[2]], result);
     }
 
     private record TestSegmentMetadata(long MinGeneration, long MaxGeneration) : ISegmentMetadata;

--- a/tests/Fugu.Core.Tests/BootstrapSegmentOrdererTests.cs
+++ b/tests/Fugu.Core.Tests/BootstrapSegmentOrdererTests.cs
@@ -1,0 +1,45 @@
+﻿using Fugu.Utils;
+
+namespace Fugu.Core.Tests;
+
+public class BootstrapSegmentOrdererTests
+{
+    [Fact]
+    public void GetBootstrapOrder_EmptySegmentsList_ReturnsEmpty()
+    {
+        var result = BootstrapSegmentOrderer.GetBootstrapOrder([]);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void GetBootstrapOrder_NonOverlappingContiguousRanges_LoadsInGenerationOrder()
+    {
+        ISegmentMetadata[] segments =
+        [
+            new TestSegmentMetadata(2, 5),
+            new TestSegmentMetadata(1, 1),
+            new TestSegmentMetadata(6, 7),
+        ];
+
+        var result = BootstrapSegmentOrderer.GetBootstrapOrder(segments);
+
+        Assert.Equal([segments[1], segments[0], segments[2]], result);
+    }
+
+    [Fact]
+    public void GetBootstrapOrder_EquivalentRanges_PrefersSmallerSegments()
+    {
+        ISegmentMetadata[] segments =
+        [
+            new TestSegmentMetadata(3, 3),
+            new TestSegmentMetadata(1, 3),          // This one should be ignored, since the other two cover the entire 1-3 range.
+            new TestSegmentMetadata(1, 2),
+        ];
+
+        var result = BootstrapSegmentOrderer.GetBootstrapOrder(segments);
+
+        Assert.Equal([segments[2], segments[0]], result);
+    }
+
+    private record TestSegmentMetadata(long MinGeneration, long MaxGeneration) : ISegmentMetadata;
+}

--- a/tests/Fugu.Core.Tests/Fugu.Core.Tests.csproj
+++ b/tests/Fugu.Core.Tests/Fugu.Core.Tests.csproj
@@ -16,7 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Resolves which segments to load during bootstrapping, in which order; and which to discard.

The existing implementation does not work correctly in situations where the store shut down in a dirty state, e.g., with half-written compaction segments. This PR extends the existing logic to address edge cases in which segment generations may be duplicated, overlap fully or partly, or be non-contiguous.