### PR TITLE
Improve store stats tracking

### DIFF
--- a/src/Fugu.Core/Actors/CompactionActor.cs
+++ b/src/Fugu.Core/Actors/CompactionActor.cs
@@ -83,7 +83,7 @@ public sealed class CompactionActor
                 if (utilization < 0.5)
                 {
                     // We need to compact. Identify a suitable range of source segments.
-                    var statsArray = message.Stats.Values.ToArray();
+                    var statsArray = message.Stats.Select(kvp => kvp.Value).ToArray();
                     var (start, length) = ChooseCompactionSourceRange(statsArray);
                     var sourceStats = message.Stats.Skip(start).Take(length).ToArray();
 

--- a/src/Fugu.Core/Actors/IndexActor.cs
+++ b/src/Fugu.Core/Actors/IndexActor.cs
@@ -177,7 +177,7 @@ public sealed partial class IndexActor
                     statsBuilder.OnTombstoneAdded(tombstone);
                 }
 
-                _statsTracker.Add(statsBuilder);
+                _statsTracker.MergeCompactedStats(statsBuilder);
 
                 var index = _indexBuilder.ToImmutable();
                 var stats = _statsTracker.ToImmutable();

--- a/src/Fugu.Core/Actors/IndexActor.cs
+++ b/src/Fugu.Core/Actors/IndexActor.cs
@@ -117,7 +117,7 @@ public sealed partial class IndexActor
                 await _indexUpdatedChannelWriter.WriteAsync(
                     new IndexUpdated(Clock: _clock, Index: index));
 
-                if (!stats.IsEmpty)
+                if (stats.Count > 0)
                 {
                     await _segmentStatsUpdatedChannelWriter.WriteAsync(
                         new SegmentStatsUpdated(Clock: _clock, Stats: stats, Index: index));
@@ -185,7 +185,7 @@ public sealed partial class IndexActor
                 await _indexUpdatedChannelWriter.WriteAsync(
                     new IndexUpdated(Clock: _clock, Index: index));
 
-                if (!stats.IsEmpty)
+                if (stats.Count > 0)
                 {
                     // The following write may not succeed when the store is shutting down because the
                     // ChangesWritten processing loop will complete this channel after when it exits.

--- a/src/Fugu.Core/Channels/SegmentStatsUpdated.cs
+++ b/src/Fugu.Core/Channels/SegmentStatsUpdated.cs
@@ -7,10 +7,10 @@ namespace Fugu.Channels;
 /// a result of an index update.
 /// </summary>
 /// <param name="Clock">Logical clock value.</param>
-/// <param name="Stats">Usage stats for all segments part of the index.</param>
+/// <param name="AllStats">Usage stats for all segments part of the index.</param>
 /// <param name="Index">State of the index at the given clock value.</param>
 public readonly record struct SegmentStatsUpdated(
     VectorClock Clock,
-    IReadOnlyList<KeyValuePair<Segment, SegmentStats>> Stats,
+    StoreStats AllStats,
     IReadOnlyDictionary<byte[], IndexEntry> Index
 );

--- a/src/Fugu.Core/Channels/SegmentStatsUpdated.cs
+++ b/src/Fugu.Core/Channels/SegmentStatsUpdated.cs
@@ -11,6 +11,6 @@ namespace Fugu.Channels;
 /// <param name="Index">State of the index at the given clock value.</param>
 public readonly record struct SegmentStatsUpdated(
     VectorClock Clock,
-    IReadOnlyDictionary<Segment, SegmentStats> Stats,
+    IReadOnlyList<KeyValuePair<Segment, SegmentStats>> Stats,
     IReadOnlyDictionary<byte[], IndexEntry> Index
 );

--- a/src/Fugu.Core/Utils/StoreStats.cs
+++ b/src/Fugu.Core/Utils/StoreStats.cs
@@ -1,0 +1,5 @@
+﻿namespace Fugu.Utils;
+
+public readonly record struct StoreStats(
+    IReadOnlyList<Segment> Keys,
+    IReadOnlyList<SegmentStats> Stats);

--- a/src/Fugu.Core/Utils/StoreStatsTracker.cs
+++ b/src/Fugu.Core/Utils/StoreStatsTracker.cs
@@ -2,17 +2,14 @@
 
 namespace Fugu.Utils;
 
-public sealed class SegmentStatsTracker
+public sealed class StoreStatsTracker
 {
     private readonly ImmutableArray<Segment>.Builder _keysBuilder = ImmutableArray.CreateBuilder<Segment>();
     private readonly ImmutableList<SegmentStats>.Builder _statsBuilder = ImmutableList.CreateBuilder<SegmentStats>();
 
-    public IReadOnlyList<KeyValuePair<Segment, SegmentStats>> ToImmutable()
+    public StoreStats ToImmutable()
     {
-        return Enumerable.Zip(
-            _keysBuilder,
-            _statsBuilder,
-            KeyValuePair.Create).ToArray();
+        return new StoreStats(_keysBuilder.ToImmutable(), _statsBuilder.ToImmutable());
     }
 
     public void OnIndexEntryDisplaced(byte[] key, IndexEntry indexEntry)

--- a/tests/Fugu.Core.Tests/Fugu.Core.Tests.csproj
+++ b/tests/Fugu.Core.Tests/Fugu.Core.Tests.csproj
@@ -16,7 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.1">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/Fugu.Core.Tests/StoreStatsTrackerTests.cs
+++ b/tests/Fugu.Core.Tests/StoreStatsTrackerTests.cs
@@ -3,13 +3,13 @@ using Fugu.Utils;
 
 namespace Fugu.Core.Tests;
 
-public class SegmentStatsTrackerTests
+public class StoreStatsTrackerTests
 {
     [Fact]
     public async Task Add_SegmentWithSinglePayload_ReflectsPayloadInStats()
     {
         // Arrange tracker and some moving bits we need to make it track a (fictional) payload
-        var tracker = new SegmentStatsTracker();
+        var tracker = new StoreStatsTracker();
 
         var storage = new InMemoryStorage();
         var slab = await storage.CreateSlabAsync();
@@ -22,10 +22,11 @@ public class SegmentStatsTrackerTests
         tracker.Add(builder);
 
         var stats = tracker.ToImmutable();
-        var singleStatsItem = Assert.Single(stats);
+        var singleKey = Assert.Single(stats.Keys);
+        var singleStat = Assert.Single(stats.Stats);
 
-        Assert.Same(segment, singleStatsItem.Key);
-        Assert.Equal(payload.Key.Length + payload.Value.Length, singleStatsItem.Value.LiveBytes);
-        Assert.Equal(0, singleStatsItem.Value.StaleBytes);
+        Assert.Same(segment, singleKey);
+        Assert.Equal(payload.Key.Length + payload.Value.Length, singleStat.LiveBytes);
+        Assert.Equal(0, singleStat.StaleBytes);
     }
 }


### PR DESCRIPTION
The existing implementation uses an `ImmutableSortedDictionary` to track completed segments along with their usage stats. While concise, this incurs significant extra allocations during updates and requires `CompactionActor` to materialize the dictionary to obtain the flat list of keys and stats.

Therefore, this PR adapts the implementation such that:

* Segments (keys) and their associated stats are stored in parallel collections.
* Instead of a sorted dictionary, these collections use array/list-like collection types for greater density.