### PR TITLE
Add file-based backing storage

### DIFF
--- a/src/Fugu.Core/IO/FileSlab.cs
+++ b/src/Fugu.Core/IO/FileSlab.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.Win32.SafeHandles;
+
+namespace Fugu.IO;
+
+public sealed class FileSlab : IWritableSlab, ISlab, IDisposable
+{
+    private readonly SafeFileHandle _handle;
+    private readonly FileStream _stream;
+
+    public FileSlab(string path)
+    {
+        // Create write-only output stream. This creates the file itself. When writing finishes, the
+        // SegmentWriter will close the attached PipeWriter, which in turn will close this underlying stream.
+        _stream = new FileStream(path, new FileStreamOptions
+        {
+            Mode = FileMode.CreateNew,
+            Access = FileAccess.Write,
+            Share = FileShare.Read,
+            Options = FileOptions.Asynchronous,
+            BufferSize = 64 * 4096,
+        });
+
+        // Create a separate handle for reading. Note that we cannot use _stream.SafeFileHandle because the latter
+        // will become invalid when the output stream is closed after completing a segment.
+        _handle = File.OpenHandle(
+            path,
+            mode: FileMode.Open,
+            access: FileAccess.Read,
+            share: FileShare.ReadWrite,
+            options: FileOptions.Asynchronous);
+    }
+
+    public Stream Output => _stream;
+
+    public long Length => _stream.Length;
+
+    public void Dispose()
+    {
+        // _stream is already disposed at this point because the attached writer has shut down and has closed its output stream.
+        _handle.Dispose();
+    }
+
+    public ValueTask<int> ReadAsync(Memory<byte> buffer, long offset, CancellationToken cancellationToken = default)
+    {
+        return RandomAccess.ReadAsync(_handle, buffer, offset, cancellationToken);
+    }
+}

--- a/src/Fugu.Core/IO/FileStorage.cs
+++ b/src/Fugu.Core/IO/FileStorage.cs
@@ -10,10 +10,8 @@ public sealed class FileStorage : IBackingStorage, IDisposable
     {
         ArgumentException.ThrowIfNullOrEmpty(path);
 
-        if (!Path.Exists(path))
-        {
-            throw new InvalidOperationException($"The provided path '{path}' does not exist.");
-        }
+        // Ensure the given path exists.
+        Directory.CreateDirectory(path);
 
         _path = path;
     }

--- a/src/Fugu.Core/IO/FileStorage.cs
+++ b/src/Fugu.Core/IO/FileStorage.cs
@@ -1,0 +1,60 @@
+﻿namespace Fugu.IO;
+
+public sealed class FileStorage : IBackingStorage, IDisposable
+{
+    private readonly string _path;
+    private readonly object _sync = new();
+    private readonly Dictionary<string, FileSlab> _slabs = new();
+
+    public FileStorage(string path)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+
+        if (!Path.Exists(path))
+        {
+            throw new InvalidOperationException($"The provided path '{path}' does not exist.");
+        }
+
+        _path = path;
+    }
+
+    public ValueTask<IWritableSlab> CreateSlabAsync()
+    {
+        var fileName = Path.ChangeExtension(Path.GetRandomFileName(), "slab");
+        var filePath = Path.Combine(_path, fileName);
+
+        var slab = new FileSlab(filePath);
+
+        _slabs.Add(filePath, slab);
+
+        return ValueTask.FromResult<IWritableSlab>(slab);
+    }
+
+    public ValueTask<IReadOnlyCollection<ISlab>> GetAllSlabsAsync()
+    {
+        foreach (var filePath in Directory.EnumerateFiles(_path, "*.slab"))
+        {
+            if (!_slabs.ContainsKey(filePath))
+            {
+                // TODO: construct slab from filePath and add it to the dictionary.
+            }
+        }
+
+        return ValueTask.FromResult<IReadOnlyCollection<ISlab>>([]);
+    }
+
+    public ValueTask RemoveSlabAsync(ISlab slab)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Dispose()
+    {
+        foreach (var slab in _slabs.Values)
+        {
+            slab.Dispose();
+        }
+
+        _slabs.Clear();
+    }
+}

--- a/src/Fugu.Core/IO/FileStorage.cs
+++ b/src/Fugu.Core/IO/FileStorage.cs
@@ -49,7 +49,11 @@ public sealed class FileStorage : IBackingStorage, IDisposable
     {
         if (slab is FileSlab fileSlab)
         {
-            _slabs.Remove(fileSlab.Path);
+            if (_slabs.Remove(fileSlab.Path))
+            {
+                fileSlab.Dispose();
+                File.Delete(fileSlab.Path);
+            }
         }
 
         return ValueTask.CompletedTask;

--- a/src/Fugu.Core/IO/FileStorage.cs
+++ b/src/Fugu.Core/IO/FileStorage.cs
@@ -23,7 +23,7 @@ public sealed class FileStorage : IBackingStorage, IDisposable
         var fileName = Path.ChangeExtension(Path.GetRandomFileName(), "slab");
         var filePath = Path.Combine(_path, fileName);
 
-        var slab = new FileSlab(filePath);
+        var slab = FileSlab.Create(filePath);
 
         _slabs.Add(filePath, slab);
 
@@ -37,15 +37,22 @@ public sealed class FileStorage : IBackingStorage, IDisposable
             if (!_slabs.ContainsKey(filePath))
             {
                 // TODO: construct slab from filePath and add it to the dictionary.
+                var slab = FileSlab.Open(filePath);
+                _slabs.Add(filePath, slab);
             }
         }
 
-        return ValueTask.FromResult<IReadOnlyCollection<ISlab>>([]);
+        return ValueTask.FromResult<IReadOnlyCollection<ISlab>>(_slabs.Values);
     }
 
     public ValueTask RemoveSlabAsync(ISlab slab)
     {
-        throw new NotImplementedException();
+        if (slab is FileSlab fileSlab)
+        {
+            _slabs.Remove(fileSlab.Path);
+        }
+
+        return ValueTask.CompletedTask;
     }
 
     public void Dispose()

--- a/src/Fugu.Core/IO/InMemorySlab.cs
+++ b/src/Fugu.Core/IO/InMemorySlab.cs
@@ -2,7 +2,7 @@
 
 namespace Fugu.IO;
 
-public class InMemorySlab : IWritableSlab, ISlab
+public sealed class InMemorySlab : IWritableSlab, ISlab
 {
     private readonly ArrayBufferWriter<byte> _arrayBufferWriter;
     private readonly ReaderWriterLockSlim _readerWriterLock;

--- a/src/Fugu.Core/IO/SegmentWriter.cs
+++ b/src/Fugu.Core/IO/SegmentWriter.cs
@@ -28,7 +28,10 @@ public sealed class SegmentWriter
     public static async ValueTask<SegmentWriter> CreateAsync(IWritableSlab outputSlab, long minGeneration, long maxGeneration)
     {
         var segment = new Segment(minGeneration, maxGeneration, outputSlab);
+
+        // By default, completing the pipe writer will automatically close the underlying stream.
         var pipeWriter = PipeWriter.Create(outputSlab.Output);
+
         var initialOffset = WriteSegmentHeader(pipeWriter, minGeneration, maxGeneration);
         await pipeWriter.FlushAsync();
 


### PR DESCRIPTION
Adds `FileStorage` and `FileSlab` types to provide a durable, file-backed persistence option in addition to the existing, ephemeral in-memory implementation.